### PR TITLE
Downgrade Android min sdk version to 21

### DIFF
--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -47,7 +47,7 @@ android {
         applicationId "com.bbflight.background_downloader_example"
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-build-configuration.
-        minSdkVersion 24
+        minSdkVersion 21
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName


### PR DESCRIPTION
We are considering using your library however out min SDK version for Android is 21. We have tested the sample app with it and it seems to work as expected. Please consider merging this pull request as there doesn't seem to be any apparent reason to target only > API 24.