### PR TITLE
Notifications tap and open file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ The file opening behavior is platform dependent, and while you should check the 
 
 Note that on Android, files stored in the `BaseDirectory.applicationDocuments` cannot be opened. You need to download to a different base directory (e.g. `.applicationSupport`) or move the file to shared storage before attempting to open it.
 
+If all you want to do on notification tap is to open the file, you can simplify the process by 
+adding `tapOpensFile: true` to your call to `configureNotifications`, and you don't need to 
+register a `taskNotificationTapCallback`.
+
 ## 5.5.0
 
 Adds `withSuggestedFilename` for `DownloadTask`. Use:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+## 5.6.0
+
+Adds handler for when the user taps a notification, and an `openFile` method to open a file using the platform-specific convention.
+
+To handle notification taps, register a callback that takes `Task` and `NotificationType` as parameters:
+
+```
+FileDownloader().registerCallbacks(
+            taskNotificationTapCallback: myNotificationTapCallback);
+            
+void myNotificationTapCallback(Task task, NotificationType notificationType) {
+    print('Tapped notification $notificationType for taskId ${task.taskId}');
+  }
+```
+
+To open a file, call `FileDownloader().openFile` and supply either a `Task` or a full `filePath` (but not both) and optionally a `mimeType` to assist the Platform in choosing the right application to use to open the file.
+The file opening behavior is platform dependent, and while you should check the return value of the call to `openFile`, error checking is not fully consistent.
+
+Note that on Android, files stored in the `BaseDirectory.applicationDocuments` cannot be opened. You need to download to a different base directory (e.g. `.applicationSupport`) or move the file to shared storage before attempting to open it.
+
 ## 5.5.0
 
 Adds `withSuggestedFilename` for `DownloadTask`. Use:
@@ -18,7 +38,7 @@ Fix issue #34 with `moveToSharedStorage` on iOS
 
 ## 5.4.5
 
-An invalid url in the `Task` now results in `false` being returned from the `enqueue` call on 
+An invalid url in the `Task` now results in `false` being returned from the `enqueue` call on
 all platforms. Previously, the behavior was inconsistent.
 
 ## 5.4.4
@@ -30,7 +50,7 @@ Added optional properties to `UploadTask` related to multi-part uploads:
 
 ## 5.4.3
 
-Added optional `mimeType` parameter for calls to `moveToSharedStorage` and 
+Added optional `mimeType` parameter for calls to `moveToSharedStorage` and
 `moveFileToSharedStorage`. This sets the mimeType
 directly, instead of relying on the system to determine the mime type based on the file extension.
 Note that this may change the filename - for example, when moving the test file `google.html` to

--- a/README.md
+++ b/README.md
@@ -225,14 +225,22 @@ You can interact with the `database` using
 
 On iOS and Android, for downloads only, the downloader can generate notifications to keep the user informed of progress also when the app is in the background, and allow pause/resume and cancellation of an ongoing download from those notifications.
 
-Configure notifications by calling `FileDownloader().configureNotification` and supply a `TaskNotification` object for different states. For example, the following configures notifications to show only when actively running (i.e. download in progress), disappearing when the download completes or ends with an error. It will also show a progress bar and a 'cancel' button, and will substitute {filename} with the actual filename of the file being downloaded.
+Configure notifications by calling `FileDownloader().configureNotification` and supply a 
+`TaskNotification` object for different states. For example, the following configures 
+notifications to show only when actively running (i.e. download in progress), disappearing when 
+the download completes or ends with an error. It will also show a progress bar and a 'cancel' 
+button, and will substitute {filename} with the actual filename of the file being downloaded.
 ```
     FileDownloader().configureNotification(
         running: TaskNotification('Downloading', 'file: {filename}'),
         progressBar: true)
 ```
 
-To also show a notifications for other states, add a `TaskNotification` for `complete`, `error` and/or `paused`. If `paused` is configured and the task can be paused, a 'Pause' button will show for the `running` notification, next to the 'Cancel' button.
+To also show a notifications for other states, add a `TaskNotification` for `complete`, `error` 
+and/or `paused`. If `paused` is configured and the task can be paused, a 'Pause' button will 
+show for the `running` notification, next to the 'Cancel' button. To open the downloaded file 
+when the user taps the `complete` notification, add `tapOpensFile: true` to your call to 
+`configureNotification`
 
 There are three possible substitutions of the text in the `title` or `body` of a `TaskNotification`:
 * {filename} is replaced with the filename as defined in the `Task`
@@ -255,6 +263,10 @@ To open a file (e.g. in response to the user tapping a notification), call `File
 The file opening behavior is platform dependent, and while you should check the return value of the call to `openFile`, error checking is not fully consistent.
 
 Note that on Android, files stored in the `BaseDirectory.applicationDocuments` cannot be opened. You need to download to a different base directory (e.g. `.applicationSupport`) or move the file to shared storage before attempting to open it.
+
+If all you want to do on notification tap is to open the file, you can simplify the process by
+adding `tapOpensFile: true` to your call to `configureNotifications`, and you don't need to
+register a `taskNotificationTapCallback`.
 
 
 ### Setup for notifications

--- a/README.md
+++ b/README.md
@@ -249,6 +249,16 @@ The `configureNotification` call configures notification behavior for all downlo
 
 When attempting to show its first notification, the downloader will ask the user for permission to show notifications (platform version dependent) and abide by the user choice. For Android, starting with API 33, you need to add `<uses-permission android:name="android.permission.POST_NOTIFICATIONS" />` to your app's `AndroidManifest.xml`. Also on Android you can localize the button text by overriding string resources `bg_downloader_cancel`, `bg_downloader_pause`, `bg_downloader_resume` and descriptions `bg_downloader_notification_channel_name`, `bg_downloader_notification_channel_description`. Localization on iOS is not currently supported.
 
+### Opening a downloaded file
+
+To open a file (e.g. in response to the user tapping a notification), call `FileDownloader().openFile` and supply either a `Task` or a full `filePath` (but not both) and optionally a `mimeType` to assist the Platform in choosing the right application to use to open the file.
+The file opening behavior is platform dependent, and while you should check the return value of the call to `openFile`, error checking is not fully consistent.
+
+Note that on Android, files stored in the `BaseDirectory.applicationDocuments` cannot be opened. You need to download to a different base directory (e.g. `.applicationSupport`) or move the file to shared storage before attempting to open it.
+
+
+### Setup for notifications
+
 On iOS, add the following to your `AppDelegate.swift`:
 ```
    UNUserNotificationCenter.current().delegate = self as UNUserNotificationCenterDelegate
@@ -257,6 +267,18 @@ or if using Objective C, add to `AppDelegate.m`:
 ```
    [UNUserNotificationCenter currentNotificationCenter].delegate = (id<UNUserNotificationCenterDelegate>) self;
 ```
+
+To respond to the user tapping a notification, register a callback that takes `Task` and `NotificationType` as parameters:
+
+```
+FileDownloader().registerCallbacks(
+            taskNotificationTapCallback: myNotificationTapCallback);
+            
+void myNotificationTapCallback(Task task, NotificationType notificationType) {
+    print('Tapped notification $notificationType for taskId ${task.taskId}');
+  }
+```
+
 
 ## Shared and scoped storage
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -46,11 +46,11 @@ android {
 }
 
 dependencies {
-    implementation "androidx.work:work-runtime-ktx:2.8.0"
+    implementation "androidx.work:work-runtime-ktx:2.8.1"
     implementation "androidx.concurrent:concurrent-futures-ktx:1.1.0"
     implementation "androidx.preference:preference-ktx:1.2.0"
     implementation 'com.google.code.gson:gson:2.8.9'
-    implementation "androidx.core:core-ktx:1.9.0"
+    implementation "androidx.core:core-ktx:1.10.0"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }
 repositories {

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -21,12 +21,13 @@
 
         <provider
             android:name="com.bbflight.background_downloader.OpenFileProvider"
-            android:authorities="com.bbflight.background_downloader.fileprovider"
+            android:authorities="${applicationId}.com.bbflight.background_downloader.fileprovider"
             android:exported="false"
-            android:grantUriPermissions="true">
+            android:grantUriPermissions="true"
+            tools:replace="android:authorities">
             <meta-data
                 android:name="android.support.FILE_PROVIDER_PATHS"
-                android:resource="@xml/file_paths" />
+                android:resource="@xml/bgd_file_paths" />
         </provider>
 
     </application>

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,7 +1,22 @@
-<manifest package="com.bbflight.background_downloader"
+<manifest xmlns:tools="http://schemas.android.com/tools"
+    package="com.bbflight.background_downloader"
     xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <application>
-        <receiver android:name="NotificationRcvr"/>
+    <application
+        android:enableOnBackInvokedCallback="true"
+        tools:targetApi="tiramisu"
+        >
+
+        <receiver android:name="NotificationRcvr" android:exported="false">
+            <intent-filter>
+                <action android:name="com.bbflight.background_downloader.cancelActive" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="com.bbflight.background_downloader.pause" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="com.bbflight.background_downloader.resume" />
+            </intent-filter>
+        </receiver>
     </application>
 </manifest>

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -18,5 +18,16 @@
                 <action android:name="com.bbflight.background_downloader.resume" />
             </intent-filter>
         </receiver>
+
+        <provider
+            android:name="com.bbflight.background_downloader.OpenFileProvider"
+            android:authorities="com.bbflight.background_downloader.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
+
     </application>
 </manifest>

--- a/android/src/main/kotlin/com/bbflight/background_downloader/BackgroundDownloaderPlugin.kt
+++ b/android/src/main/kotlin/com/bbflight/background_downloader/BackgroundDownloaderPlugin.kt
@@ -6,12 +6,10 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
-import android.net.Uri
 import android.os.Build
 import android.util.Log
 import android.util.Patterns
 import androidx.core.app.ActivityCompat
-import androidx.core.content.ContextCompat.startActivity
 import androidx.preference.PreferenceManager
 import androidx.work.*
 import com.bbflight.background_downloader.TaskWorker.Companion.keyNotificationConfig
@@ -35,7 +33,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
-import java.io.File
 import java.lang.Long.min
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
@@ -52,7 +49,7 @@ import kotlin.math.pow
  * [TaskWorker]
  */
 class BackgroundDownloaderPlugin : FlutterPlugin, MethodCallHandler, ActivityAware,
-    PluginRegistry.RequestPermissionsResultListener {
+        PluginRegistry.RequestPermissionsResultListener {
     companion object {
         const val TAG = "BackgroundDownloader"
         const val keyTasksMap = "com.bbflight.background_downloader.taskMap"
@@ -81,12 +78,12 @@ class BackgroundDownloaderPlugin : FlutterPlugin, MethodCallHandler, ActivityAwa
          * Enqueue a WorkManager task based on the provided parameters
          */
         suspend fun doEnqueue(
-            context: Context,
-            taskJsonMapString: String,
-            notificationConfigJsonString: String?,
-            tempFilePath: String?,
-            startByte: Long?,
-            initialDelayMillis: Long = 0
+                context: Context,
+                taskJsonMapString: String,
+                notificationConfigJsonString: String?,
+                tempFilePath: String?,
+                startByte: Long?,
+                initialDelayMillis: Long = 0
         ): Boolean {
             val task = Task(gson.fromJson(taskJsonMapString, jsonMapType))
             Log.i(TAG, "Enqueuing task with id ${task.taskId}")
@@ -101,15 +98,15 @@ class BackgroundDownloaderPlugin : FlutterPlugin, MethodCallHandler, ActivityAwa
             }
             if (tempFilePath != null && startByte != null) {
                 dataBuilder.putString(keyTempFilename, tempFilePath)
-                    .putLong(keyStartByte, startByte)
+                        .putLong(keyStartByte, startByte)
             }
             val data = dataBuilder.build()
             val constraints = Constraints.Builder().setRequiredNetworkType(
-                if (task.requiresWiFi) NetworkType.UNMETERED else NetworkType.CONNECTED
+                    if (task.requiresWiFi) NetworkType.UNMETERED else NetworkType.CONNECTED
             ).build()
             val requestBuilder = OneTimeWorkRequestBuilder<TaskWorker>().setInputData(data)
-                .setConstraints(constraints).addTag(TAG).addTag("taskId=${task.taskId}")
-                .addTag("group=${task.group}")
+                    .setConstraints(constraints).addTag(TAG).addTag("taskId=${task.taskId}")
+                    .addTag("group=${task.group}")
             if (initialDelayMillis != 0L) {
                 requestBuilder.setInitialDelay(initialDelayMillis, TimeUnit.MILLISECONDS)
             }
@@ -122,7 +119,7 @@ class BackgroundDownloaderPlugin : FlutterPlugin, MethodCallHandler, ActivityAwa
                 val prefs = PreferenceManager.getDefaultSharedPreferences(context)
                 if (initialDelayMillis == 0L) {
                     TaskWorker.processStatusUpdate(
-                        task, TaskStatus.enqueued, prefs
+                            task, TaskStatus.enqueued, prefs
                     )
                 } else {
                     delay(min(100L, initialDelayMillis))
@@ -130,8 +127,8 @@ class BackgroundDownloaderPlugin : FlutterPlugin, MethodCallHandler, ActivityAwa
                 }
             } catch (e: Throwable) {
                 Log.w(
-                    TAG,
-                    "Unable to start background request for taskId ${task.taskId} in operation: $operation"
+                        TAG,
+                        "Unable to start background request for taskId ${task.taskId} in operation: $operation"
                 )
                 return false
             }
@@ -140,7 +137,7 @@ class BackgroundDownloaderPlugin : FlutterPlugin, MethodCallHandler, ActivityAwa
                 val prefs = PreferenceManager.getDefaultSharedPreferences(context)
                 val jsonString = prefs.getString(keyTasksMap, "{}")
                 val tasksMap =
-                    gson.fromJson<Map<String, Any>>(jsonString, jsonMapType).toMutableMap()
+                        gson.fromJson<Map<String, Any>>(jsonString, jsonMapType).toMutableMap()
                 tasksMap[task.taskId] = gson.toJson(task.toJsonMap())
                 val editor = prefs.edit()
                 editor.putString(keyTasksMap, gson.toJson(tasksMap))
@@ -155,7 +152,7 @@ class BackgroundDownloaderPlugin : FlutterPlugin, MethodCallHandler, ActivityAwa
          * The [taskId] must be managed by the [workManager]
          */
         suspend fun cancelActiveTaskWithId(
-            context: Context, taskId: String, workManager: WorkManager
+                context: Context, taskId: String, workManager: WorkManager
         ): Boolean {
             val workInfos = withContext(Dispatchers.IO) {
                 workManager.getWorkInfosByTag("taskId=$taskId").get()
@@ -174,7 +171,7 @@ class BackgroundDownloaderPlugin : FlutterPlugin, MethodCallHandler, ActivityAwa
                         val taskJsonMap = tasksMap[taskId] as String?
                         if (taskJsonMap != null) {
                             val task = Task(
-                                gson.fromJson(taskJsonMap, jsonMapType)
+                                    gson.fromJson(taskJsonMap, jsonMapType)
                             )
                             TaskWorker.processStatusUpdate(task, TaskStatus.canceled, prefs)
                         } else {
@@ -240,12 +237,12 @@ class BackgroundDownloaderPlugin : FlutterPlugin, MethodCallHandler, ActivityAwa
             // and per https://github.com/firebase/flutterfire/issues/9689 other
             // plugins can create multiple instances of the plugin
             backgroundChannel = MethodChannel(
-                flutterPluginBinding.binaryMessenger,
-                "com.bbflight.background_downloader.background"
+                    flutterPluginBinding.binaryMessenger,
+                    "com.bbflight.background_downloader.background"
             )
         }
         channel = MethodChannel(
-            flutterPluginBinding.binaryMessenger, "com.bbflight.background_downloader"
+                flutterPluginBinding.binaryMessenger, "com.bbflight.background_downloader"
         )
         channel?.setMethodCallHandler(this)
         // set context and register notification broadcast receivers
@@ -302,7 +299,7 @@ class BackgroundDownloaderPlugin : FlutterPlugin, MethodCallHandler, ActivityAwa
                 "moveToSharedStorage" -> methodMoveToSharedStorage(call, result)
                 "openFile" -> methodOpenFile(call, result)
                 "forceFailPostOnBackgroundChannel" -> methodForceFailPostOnBackgroundChannel(
-                    call, result
+                        call, result
                 )
 
                 else -> result.notImplemented()
@@ -333,13 +330,13 @@ class BackgroundDownloaderPlugin : FlutterPlugin, MethodCallHandler, ActivityAwa
             startByte = null
         }
         result.success(
-            doEnqueue(
-                applicationContext,
-                taskJsonMapString,
-                notificationConfigJsonString,
-                tempFilePath,
-                startByte
-            )
+                doEnqueue(
+                        applicationContext,
+                        taskJsonMapString,
+                        notificationConfigJsonString,
+                        tempFilePath,
+                        startByte
+                )
         )
     }
 
@@ -354,7 +351,7 @@ class BackgroundDownloaderPlugin : FlutterPlugin, MethodCallHandler, ActivityAwa
         var counter = 0
         val workManager = WorkManager.getInstance(applicationContext)
         val workInfos = workManager.getWorkInfosByTag(TAG).get()
-            .filter { !it.state.isFinished && it.tags.contains("group=$group") }
+                .filter { !it.state.isFinished && it.tags.contains("group=$group") }
         for (workInfo in workInfos) {
             workManager.cancelWorkById(workInfo.id)
             counter++
@@ -370,7 +367,7 @@ class BackgroundDownloaderPlugin : FlutterPlugin, MethodCallHandler, ActivityAwa
         val group = call.arguments as String
         val workManager = WorkManager.getInstance(applicationContext)
         val workInfos = workManager.getWorkInfosByTag(TAG).get()
-            .filter { !it.state.isFinished && it.tags.contains("group=$group") }
+                .filter { !it.state.isFinished && it.tags.contains("group=$group") }
         val tasksAsListOfJsonStrings = mutableListOf<String>()
         prefsLock.read {
             val prefs = PreferenceManager.getDefaultSharedPreferences(applicationContext)
@@ -483,32 +480,32 @@ class BackgroundDownloaderPlugin : FlutterPlugin, MethodCallHandler, ActivityAwa
         val mimeType = args[3] as String?
         // first check and potentially ask for permissions
         if (Build.VERSION.SDK_INT < 30 && ActivityCompat.checkSelfPermission(
-                applicationContext, Manifest.permission.WRITE_EXTERNAL_STORAGE
-            ) != PackageManager.PERMISSION_GRANTED
+                        applicationContext, Manifest.permission.WRITE_EXTERNAL_STORAGE
+                ) != PackageManager.PERMISSION_GRANTED
         ) {
             if (activity != null) {
                 activity?.requestPermissions(
-                    arrayOf(Manifest.permission.WRITE_EXTERNAL_STORAGE),
-                    externalStoragePermissionRequestCode
+                        arrayOf(Manifest.permission.WRITE_EXTERNAL_STORAGE),
+                        externalStoragePermissionRequestCode
                 )
                 externalStoragePermissionCompleter.thenApplyAsync {
                     result.success(
-                        moveToSharedStorage(
-                            applicationContext, filePath, destination, directory, mimeType
-                        )
+                            moveToSharedStorage(
+                                    applicationContext, filePath, destination, directory, mimeType
+                            )
                     )
                 }
                 return
             }
         }
         result.success(
-            moveToSharedStorage(
-                applicationContext,
-                filePath,
-                destination,
-                directory,
-                mimeType
-            )
+                moveToSharedStorage(
+                        applicationContext,
+                        filePath,
+                        destination,
+                        directory,
+                        mimeType
+                )
         )
     }
 
@@ -522,7 +519,7 @@ class BackgroundDownloaderPlugin : FlutterPlugin, MethodCallHandler, ActivityAwa
         val args = call.arguments as List<*>
         val taskJsonMapString = args[0] as String?
         val task = if (taskJsonMapString != null) Task(
-            Gson().fromJson(taskJsonMapString, jsonMapType)
+                Gson().fromJson(taskJsonMapString, jsonMapType)
         ) else null
         val filePath = args[1] as String? ?: task!!.filePath(applicationContext)
         val mimeType = args[2] as String? ?: getMimeType(filePath)
@@ -558,19 +555,19 @@ class BackgroundDownloaderPlugin : FlutterPlugin, MethodCallHandler, ActivityAwa
      */
     private fun handleIntent(intent: Intent?): Boolean {
         if (intent != null && intent.action == NotificationRcvr.actionTap) {
+            val taskJsonMapString =
+                    intent.extras?.getString(NotificationRcvr.bundleTask)
+            val notificationTypeOrdinal =
+                    intent.getIntExtra(NotificationRcvr.bundleNotificationType, 0)
             scope?.launch {
                 var retries = 0
                 var success = false
                 while (retries < 5 && !success) {
                     try {
                         if (backgroundChannel != null) {
-                            val taskJsonString =
-                                intent.extras?.getString(NotificationRcvr.bundleTask)
-                            val notificationTypeOrdinal =
-                                intent.getIntExtra(NotificationRcvr.bundleNotificationType, 0)
                             backgroundChannel?.invokeMethod(
-                                "notificationTap",
-                                listOf(taskJsonString, notificationTypeOrdinal)
+                                    "notificationTap",
+                                    listOf(taskJsonMapString, notificationTypeOrdinal)
                             )
                             success = true
                         }
@@ -580,6 +577,20 @@ class BackgroundDownloaderPlugin : FlutterPlugin, MethodCallHandler, ActivityAwa
                         delay(timeMillis = 100 * 2.0.pow(retries).toLong())
                         retries++
                     }
+                }
+            }
+            // check for 'tapOpensFile'
+            if (notificationTypeOrdinal == NotificationType.complete.ordinal) {
+                val task = Task(gson.fromJson(taskJsonMapString, jsonMapType))
+                val notificationConfigJsonString =
+                        intent.extras?.getString(NotificationRcvr.bundleNotificationConfig)
+                val notificationConfig =
+                        if (notificationConfigJsonString != null) gson.fromJson(
+                                notificationConfigJsonString, NotificationConfig::class.java
+                        ) else null
+                if (notificationConfig?.tapOpensFile == true && activity != null) {
+                    val filePath = task.filePath(activity!!)
+                    doOpenFile(activity!!, filePath, getMimeType(filePath))
                 }
             }
             return true
@@ -613,10 +624,10 @@ class BackgroundDownloaderPlugin : FlutterPlugin, MethodCallHandler, ActivityAwa
     }
 
     override fun onRequestPermissionsResult(
-        requestCode: Int, permissions: Array<out String>, grantResults: IntArray
+            requestCode: Int, permissions: Array<out String>, grantResults: IntArray
     ): Boolean {
         val granted =
-            (grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED)
+                (grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED)
         return when (requestCode) {
             notificationPermissionRequestCode -> {
                 requestingNotificationPermission = false

--- a/android/src/main/kotlin/com/bbflight/background_downloader/Models.kt
+++ b/android/src/main/kotlin/com/bbflight/background_downloader/Models.kt
@@ -29,74 +29,74 @@ enum class Updates {
  */
 
 class Task(
-        val taskId: String,
-        val url: String,
-        val filename: String,
-        val headers: Map<String, String>,
-        val post: String?,
-        val fileField: String,
-        val mimeType: String,
-        val fields: Map<String, String>,
-        val directory: String,
-        val baseDirectory: BaseDirectory,
-        val group: String,
-        val updates: Updates,
-        val requiresWiFi: Boolean,
-        val retries: Int,
-        val retriesRemaining: Int,
-        val allowPause: Boolean,
-        val metaData: String,
-        val creationTime: Long, // untouched, so kept as integer on Android side
-        val taskType: String // distinction between DownloadTask and UploadTask
+    val taskId: String,
+    val url: String,
+    val filename: String,
+    val headers: Map<String, String>,
+    val post: String?,
+    val fileField: String,
+    val mimeType: String,
+    val fields: Map<String, String>,
+    val directory: String,
+    val baseDirectory: BaseDirectory,
+    val group: String,
+    val updates: Updates,
+    val requiresWiFi: Boolean,
+    val retries: Int,
+    val retriesRemaining: Int,
+    val allowPause: Boolean,
+    val metaData: String,
+    val creationTime: Long, // untouched, so kept as integer on Android side
+    val taskType: String // distinction between DownloadTask and UploadTask
 ) {
 
     /** Creates object from JsonMap */
     @Suppress("UNCHECKED_CAST")
     constructor(jsonMap: Map<String, Any>) : this(
-            taskId = jsonMap["taskId"] as String? ?: "",
-            url = jsonMap["url"] as String? ?: "",
-            filename = jsonMap["filename"] as String? ?: "",
-            headers = jsonMap["headers"] as Map<String, String>? ?: mutableMapOf<String, String>(),
-            post = jsonMap["post"] as String?,
-            fileField = jsonMap["fileField"] as String? ?: "",
-            mimeType = jsonMap["mimeType"] as String? ?: "",
-            fields = jsonMap["fields"] as Map<String, String>? ?: mutableMapOf<String, String>(),
-            directory = jsonMap["directory"] as String? ?: "",
-            baseDirectory = BaseDirectory.values()[(jsonMap["baseDirectory"] as Double?
-                    ?: 0).toInt()],
-            group = jsonMap["group"] as String? ?: "",
-            updates = Updates.values()[(jsonMap["updates"] as Double? ?: 0).toInt()],
-            requiresWiFi = jsonMap["requiresWiFi"] as Boolean? ?: false,
-            retries = (jsonMap["retries"] as Double? ?: 0).toInt(),
-            retriesRemaining = (jsonMap["retriesRemaining"] as Double? ?: 0).toInt(),
-            allowPause = (jsonMap["allowPause"] as Boolean? ?: false),
-            metaData = jsonMap["metaData"] as String? ?: "",
-            creationTime = (jsonMap["creationTime"] as Double? ?: 0).toLong(),
-            taskType = jsonMap["taskType"] as String? ?: ""
+        taskId = jsonMap["taskId"] as String? ?: "",
+        url = jsonMap["url"] as String? ?: "",
+        filename = jsonMap["filename"] as String? ?: "",
+        headers = jsonMap["headers"] as Map<String, String>? ?: mutableMapOf<String, String>(),
+        post = jsonMap["post"] as String?,
+        fileField = jsonMap["fileField"] as String? ?: "",
+        mimeType = jsonMap["mimeType"] as String? ?: "",
+        fields = jsonMap["fields"] as Map<String, String>? ?: mutableMapOf<String, String>(),
+        directory = jsonMap["directory"] as String? ?: "",
+        baseDirectory = BaseDirectory.values()[(jsonMap["baseDirectory"] as Double?
+            ?: 0).toInt()],
+        group = jsonMap["group"] as String? ?: "",
+        updates = Updates.values()[(jsonMap["updates"] as Double? ?: 0).toInt()],
+        requiresWiFi = jsonMap["requiresWiFi"] as Boolean? ?: false,
+        retries = (jsonMap["retries"] as Double? ?: 0).toInt(),
+        retriesRemaining = (jsonMap["retriesRemaining"] as Double? ?: 0).toInt(),
+        allowPause = (jsonMap["allowPause"] as Boolean? ?: false),
+        metaData = jsonMap["metaData"] as String? ?: "",
+        creationTime = (jsonMap["creationTime"] as Double? ?: 0).toLong(),
+        taskType = jsonMap["taskType"] as String? ?: ""
     )
 
     /** Creates JSON map of this object */
     fun toJsonMap(): Map<String, Any?> {
         return mapOf(
-                "taskId" to taskId,
-                "url" to url,
-                "filename" to filename,
-                "headers" to headers,
-                "post" to post,
-                "fileField" to fileField,
-                "mimeType" to mimeType,
-                "fields" to fields,
-                "directory" to directory,
-                "baseDirectory" to baseDirectory.ordinal, // stored as int
-                "group" to group,
-                "updates" to updates.ordinal,
-                "requiresWiFi" to requiresWiFi,
-                "retries" to retries,
-                "retriesRemaining" to retriesRemaining,
-                "allowPause" to allowPause,
-                "metaData" to metaData,
-                "creationTime" to creationTime,
-                "taskType" to taskType
+            "taskId" to taskId,
+            "url" to url,
+            "filename" to filename,
+            "headers" to headers,
+            "post" to post,
+            "fileField" to fileField,
+            "mimeType" to mimeType,
+            "fields" to fields,
+            "directory" to directory,
+            "baseDirectory" to baseDirectory.ordinal, // stored as int
+            "group" to group,
+            "updates" to updates.ordinal,
+            "requiresWiFi" to requiresWiFi,
+            "retries" to retries,
+            "retriesRemaining" to retriesRemaining,
+            "allowPause" to allowPause,
+            "metaData" to metaData,
+            "creationTime" to creationTime,
+            "taskType" to taskType
         )
     }
 
@@ -145,9 +145,9 @@ enum class TaskStatus {
 class ResumeData(val task: Task, val data: String, val requiredStartByte: Long) {
     fun toJsonMap(): MutableMap<String, Any?> {
         return mutableMapOf(
-                "task" to task.toJsonMap(),
-                "data" to data,
-                "requiredStartByte" to requiredStartByte
+            "task" to task.toJsonMap(),
+            "data" to data,
+            "requiredStartByte" to requiredStartByte
         )
     }
 }

--- a/android/src/main/kotlin/com/bbflight/background_downloader/Models.kt
+++ b/android/src/main/kotlin/com/bbflight/background_downloader/Models.kt
@@ -2,6 +2,11 @@
 
 package com.bbflight.background_downloader
 
+import android.content.Context
+import android.os.Build
+import kotlin.io.path.Path
+import kotlin.io.path.pathString
+
 /// Base directory in which files will be stored, based on their relative
 /// path.
 ///
@@ -115,6 +120,36 @@ class Task(
     /** True if this task is a DownloadTask, otherwise it is an UploadTask */
     fun isDownloadTask(): Boolean {
         return taskType != "UploadTask"
+    }
+
+    /**
+     * Returns full path (String) to the file to be downloaded
+     */
+    fun filePath(context: Context): String {
+        if (Build.VERSION.SDK_INT >= 26) {
+            val baseDirPath = when (baseDirectory) {
+                BaseDirectory.applicationDocuments -> Path(
+                    context.dataDir.path, "app_flutter"
+                ).pathString
+
+                BaseDirectory.temporary -> context.cacheDir.path
+                BaseDirectory.applicationSupport -> context.filesDir.path
+                BaseDirectory.applicationLibrary -> Path(
+                    context.filesDir.path, "Library"
+                ).pathString
+            }
+            val path = Path(baseDirPath, directory)
+            return Path(path.pathString, filename).pathString
+        } else {
+            val baseDirPath = when (baseDirectory) {
+                BaseDirectory.applicationDocuments -> "${context.dataDir.path}/app_flutter"
+                BaseDirectory.temporary -> context.cacheDir.path
+                BaseDirectory.applicationSupport -> context.filesDir.path
+                BaseDirectory.applicationLibrary -> "${context.filesDir.path}/Library"
+            }
+            return if (directory.isEmpty()) "$baseDirPath/${filename}" else
+                "$baseDirPath/${directory}/${filename}"
+        }
     }
 }
 

--- a/android/src/main/kotlin/com/bbflight/background_downloader/Notifications.kt
+++ b/android/src/main/kotlin/com/bbflight/background_downloader/Notifications.kt
@@ -1,10 +1,13 @@
 package com.bbflight.background_downloader
 
+import android.app.PendingIntent
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.os.Bundle
 import android.util.Log
 import androidx.annotation.Keep
+import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.work.WorkManager
 import com.bbflight.background_downloader.BackgroundDownloaderPlugin.Companion.TAG
@@ -40,10 +43,12 @@ class NotificationConfig(
     val complete: TaskNotification?,
     val error: TaskNotification?,
     val paused: TaskNotification?,
-    val progressBar: Boolean
+    val progressBar: Boolean,
+    val tapOpensFile: Boolean
 ) {
     override fun toString(): String {
-        return "NotificationConfig(running=$running, complete=$complete, error=$error, paused=$paused, progressBar=$progressBar)"
+        return "NotificationConfig(running=$running, complete=$complete, error=$error, " +
+                "paused=$paused, progressBar=$progressBar, tapOpensFile=$tapOpensFile)"
     }
 }
 

--- a/android/src/main/kotlin/com/bbflight/background_downloader/Notifications.kt
+++ b/android/src/main/kotlin/com/bbflight/background_downloader/Notifications.kt
@@ -68,10 +68,14 @@ class NotificationRcvr : BroadcastReceiver() {
         const val actionCancelInactive = "com.bbflight.background_downloader.cancelInactive"
         const val actionPause = "com.bbflight.background_downloader.pause"
         const val actionResume = "com.bbflight.background_downloader.resume"
+        const val actionTap = "com.bbflight.background_downloader.tap"
         const val extraBundle = "com.bbflight.background_downloader.bundle"
-        const val bundleTaskId = "taskId"
-        const val bundleTask = "task"
-        const val bundleNotificationConfig = "notificationConfig"
+        const val bundleTaskId = "com.bbflight.background_downloader.taskId"
+        const val bundleTask = "com.bbflight.background_downloader.task" // as JSON string
+        const val bundleNotificationConfig =
+            "com.bbflight.background_downloader.notificationConfig" // as JSON string
+        const val bundleNotificationType =
+            "com.bbflight.background_downloader.notificationType" // ordinal of enum
     }
 
     override fun onReceive(context: Context, intent: Intent) {
@@ -81,15 +85,14 @@ class NotificationRcvr : BroadcastReceiver() {
             runBlocking {
                 when (intent.action) {
                     actionCancelActive -> {
-                        Log.d(TAG, "active task")
                         BackgroundDownloaderPlugin.cancelActiveTaskWithId(
-                                context, taskId, WorkManager.getInstance(context)
-                            )
+                            context, taskId, WorkManager.getInstance(context)
+                        )
                     }
+
                     actionCancelInactive -> {
                         val taskJsonString = bundle.getString(bundleTask)
                         if (taskJsonString != null) {
-                            Log.d(TAG, "inactive task")
                             val task = Task(
                                 BackgroundDownloaderPlugin.gson.fromJson(
                                     taskJsonString, BackgroundDownloaderPlugin.jsonMapType
@@ -103,9 +106,11 @@ class NotificationRcvr : BroadcastReceiver() {
                             Log.d(TAG, "task was null")
                         }
                     }
+
                     actionPause -> {
                         BackgroundDownloaderPlugin.pauseTaskWithId(taskId)
                     }
+
                     actionResume -> {
                         val resumeData = BackgroundDownloaderPlugin.localResumeData[taskId]
                         if (resumeData != null) {
@@ -132,6 +137,7 @@ class NotificationRcvr : BroadcastReceiver() {
                             )
                         }
                     }
+
                     else -> {}
                 }
             }

--- a/android/src/main/kotlin/com/bbflight/background_downloader/OpenFile.kt
+++ b/android/src/main/kotlin/com/bbflight/background_downloader/OpenFile.kt
@@ -2,21 +2,20 @@ package com.bbflight.background_downloader
 
 import android.app.Activity
 import android.content.Intent
-import android.content.pm.PackageManager
 import android.util.Log
 import androidx.core.content.FileProvider
 import androidx.core.content.FileProvider.getUriForFile
 import java.io.File
 
 
-class OpenFileProvider : FileProvider()
+class OpenFileProvider : FileProvider(R.xml.bgd_file_paths)
 
 fun doOpenFile(activity: Activity, filePath: String, mimeType: String): Boolean {
     val intent = Intent(Intent.ACTION_VIEW)
     try {
         if (BackgroundDownloaderPlugin.activity != null) {
             val contentUri = getUriForFile(
-                activity, "com.bbflight.background_downloader.fileprovider", File(filePath)
+                activity, activity.packageName + ".com.bbflight.background_downloader.fileprovider", File(filePath)
             )
             intent.setDataAndType(contentUri, mimeType)
             intent.addFlags(

--- a/android/src/main/kotlin/com/bbflight/background_downloader/OpenFile.kt
+++ b/android/src/main/kotlin/com/bbflight/background_downloader/OpenFile.kt
@@ -1,0 +1,32 @@
+package com.bbflight.background_downloader
+
+import android.app.Activity
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.util.Log
+import androidx.core.content.FileProvider
+import androidx.core.content.FileProvider.getUriForFile
+import java.io.File
+
+
+class OpenFileProvider : FileProvider()
+
+fun doOpenFile(activity: Activity, filePath: String, mimeType: String): Boolean {
+    val intent = Intent(Intent.ACTION_VIEW)
+    try {
+        if (BackgroundDownloaderPlugin.activity != null) {
+            val contentUri = getUriForFile(
+                activity, "com.bbflight.background_downloader.fileprovider", File(filePath)
+            )
+            intent.setDataAndType(contentUri, mimeType)
+            intent.addFlags(
+                Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+            )
+            activity.startActivity(intent)
+            return true
+        }
+    } catch (e: Exception) {
+        Log.i(BackgroundDownloaderPlugin.TAG, "Failed to open file $filePath: $e")
+    }
+    return false
+}

--- a/android/src/main/kotlin/com/bbflight/background_downloader/SharedStorage.kt
+++ b/android/src/main/kotlin/com/bbflight/background_downloader/SharedStorage.kt
@@ -194,7 +194,7 @@ private fun getRelativePath(destination: SharedStorage, directory: String): Stri
  *
  * Defaults to application/octet-stream
  */
-private fun getMimeType(fileName: String): String {
+fun getMimeType(fileName: String): String {
     val extension = fileName.substringAfterLast(".", "")
     return MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension)
             ?: "application/octet-stream"

--- a/android/src/main/kotlin/com/bbflight/background_downloader/TaskWorker.kt
+++ b/android/src/main/kotlin/com/bbflight/background_downloader/TaskWorker.kt
@@ -948,7 +948,7 @@ class TaskWorker(
             }
         }
         // action buttons
-        addActionButtons(notificationType, task, builder)
+        addNotificationActions(notificationType, task, builder)
         with(NotificationManagerCompat.from(applicationContext)) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                 // On Android 33+, check/ask for permission
@@ -974,12 +974,12 @@ class TaskWorker(
 
 
     /**
-     * Add action buttons to notification
+     * Add action to notification via buttons or tap
      *
      * Which button(s) depends on the [notificationType], and the actions require
      * access to [task] and the [builder]
      */
-    private fun addActionButtons(
+    private fun addNotificationActions(
         notificationType: NotificationType, task: Task, builder: NotificationCompat.Builder
     ) {
         val activity = BackgroundDownloaderPlugin.activity
@@ -998,7 +998,7 @@ class TaskWorker(
                 }
                 val tapPendingIntent: PendingIntent = PendingIntent.getActivity(
                     applicationContext,
-                    72382,
+                    notificationId,
                     tapIntent,
                     PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_IMMUTABLE
                 )
@@ -1133,7 +1133,6 @@ class TaskWorker(
             else -> NotificationType.error
         }
     }
-
 
 
     private fun deleteTempFile(tempFilePath: String) {

--- a/android/src/main/kotlin/com/bbflight/background_downloader/TaskWorker.kt
+++ b/android/src/main/kotlin/com/bbflight/background_downloader/TaskWorker.kt
@@ -995,6 +995,7 @@ class TaskWorker(
                     action = NotificationRcvr.actionTap
                     putExtra(NotificationRcvr.bundleTask, taskJsonString)
                     putExtra(NotificationRcvr.bundleNotificationType, notificationType.ordinal)
+                    putExtra(NotificationRcvr.bundleNotificationConfig, notificationConfigJsonString)
                 }
                 val tapPendingIntent: PendingIntent = PendingIntent.getActivity(
                     applicationContext,

--- a/android/src/main/res/xml/bgd_file_paths.xml
+++ b/android/src/main/res/xml/bgd_file_paths.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<paths>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
     <external-path
         name="external-path"
         path="."/>
@@ -11,7 +11,7 @@
         path="."/>
     <files-path
         name="files_path"
-        path="app_flutter"/>
+        path="."/>
     <cache-path
         name="cache-path"
         path="."/>

--- a/android/src/main/res/xml/file_paths.xml
+++ b/android/src/main/res/xml/file_paths.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <external-path
+        name="external-path"
+        path="."/>
+    <external-cache-path
+        name="external-cache-path"
+        path="."/>
+    <external-files-path
+        name="external-files-path"
+        path="."/>
+    <files-path
+        name="files_path"
+        path="app_flutter"/>
+    <cache-path
+        name="cache-path"
+        path="."/>
+    <external-media-path
+        name="external_media"
+        path="." />
+</paths>

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -13,7 +13,7 @@
         <activity
             android:name=".example.MainActivity"
             android:exported="true"
-            android:launchMode="singleTop"
+            android:launchMode="singleTask"
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -1,10 +1,13 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="com.bbflight.background_downloader_example">
 
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <!--  For Android below Q  -->
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"
+        tools:ignore="ScopedStorage" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        tools:ignore="ScopedStorage" />
 
     <application
         android:label="background_downloader_example"
@@ -30,6 +33,7 @@
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
+
         </activity>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->

--- a/example/integration_test/downloader_integration_test.dart
+++ b/example/integration_test/downloader_integration_test.dart
@@ -1846,6 +1846,43 @@ void main() {
       expect(await FileDownloader().enqueue(task), equals(true));
       await statusCallbackCompleter.future;
     });
+
+    testWidgets('openFile', (widgetTester) async {
+      final result = await FileDownloader().download(task);
+      expect(result, equals(TaskStatus.complete));
+      var success = await FileDownloader().openFile(task: task);
+      if (!Platform.isAndroid) {
+        expect(success, isTrue);
+        // change to a .txt file
+        final filePath = await task.filePath();
+        await File(filePath).rename(join(
+            dirname(filePath), '${basenameWithoutExtension(filePath)}.txt'));
+        task = task.copyWith(filename: 'google.txt');
+        success = await FileDownloader().openFile(task: task);
+        expect(success, isTrue);
+        success = await FileDownloader().openFile(filePath: await task.filePath());
+        expect(success, isTrue);
+        // change to a non-existent file
+        task = task.copyWith(filename: 'nonexistentFile.html');
+        success = await FileDownloader().openFile(task: task);
+        expect(success, isFalse);
+        // change to a file without extension
+        task = task.copyWith(filename: 'fileWithoutExtension');
+        success = await FileDownloader().openFile(task: task);
+        expect(success, isFalse);
+      } else {
+        expect(success, isFalse); // on Android cannot access docsdir
+        // change to a .txt file
+        final filePath = await task.filePath();
+        await File(filePath).rename(join(
+            dirname(filePath), '${basenameWithoutExtension(filePath)}.txt'));
+        task = task.copyWith(filename: 'google.txt');
+        final newFilename = await FileDownloader().moveToSharedStorage(task, SharedStorage.external);
+        print(newFilename);
+        success = await FileDownloader().openFile(filePath: newFilename);
+        expect(success, isTrue);
+      }
+    });
   });
 
   group('Shared storage', () {

--- a/example/integration_test/downloader_integration_test.dart
+++ b/example/integration_test/downloader_integration_test.dart
@@ -1860,7 +1860,8 @@ void main() {
         task = task.copyWith(filename: 'google.txt');
         success = await FileDownloader().openFile(task: task);
         expect(success, isTrue);
-        success = await FileDownloader().openFile(filePath: await task.filePath());
+        success =
+            await FileDownloader().openFile(filePath: await task.filePath());
         expect(success, isTrue);
         // change to a non-existent file
         task = task.copyWith(filename: 'nonexistentFile.html');
@@ -1877,7 +1878,8 @@ void main() {
         await File(filePath).rename(join(
             dirname(filePath), '${basenameWithoutExtension(filePath)}.txt'));
         task = task.copyWith(filename: 'google.txt');
-        final newFilename = await FileDownloader().moveToSharedStorage(task, SharedStorage.external);
+        final newFilename = await FileDownloader()
+            .moveToSharedStorage(task, SharedStorage.external);
         print(newFilename);
         success = await FileDownloader().openFile(filePath: newFilename);
         expect(success, isTrue);

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -45,7 +45,9 @@ class _MyAppState extends State<MyApp> {
             taskStatusCallback: myDownloadStatusCallback,
             taskProgressCallback: myDownloadProgressCallback,
             taskNotificationTapCallback: myNotificationTapCallback)
-        .configureNotification(
+        .configureNotificationForGroup(FileDownloader.defaultGroup,
+            // For the main download button
+            // which uses 'enqueue' and a default group
             running: TaskNotification(
                 'Download {filename}', 'File: {filename} - {progress}'),
             complete:
@@ -53,7 +55,14 @@ class _MyAppState extends State<MyApp> {
             error: TaskNotification('Download {filename}', 'Download failed'),
             paused: TaskNotification(
                 'Download {filename}', 'Paused with metadata {metadata}'),
-            progressBar: true);
+            progressBar: true)
+        .configureNotification(
+            // for the 'Download & Open' dog picture
+            // which uses 'download' which is not the .defaultGroup
+            // but the .await group so won't use the above config
+            complete:
+                TaskNotification('Download {filename}', 'Download complete'),
+            tapOpensFile: true); // dog can also open directly from tap
   }
 
   /// Process the status updates coming from the downloader
@@ -94,8 +103,7 @@ class _MyAppState extends State<MyApp> {
 
   /// Process the user tapping on a notification by printing a message
   void myNotificationTapCallback(Task task, NotificationType notificationType) {
-    debugPrint(
-        'Tapped notification $notificationType for taskId ${task.taskId}');
+    print('Tapped notification $notificationType for taskId ${task.taskId}');
   }
 
   @override

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -9,8 +9,7 @@ import 'widgets.dart';
 
 void main() {
   Logger.root.onRecord.listen((LogRecord rec) {
-    // ignore: avoid_print
-    print('${rec.loggerName}>${rec.level.name}: ${rec.time}: ${rec.message}');
+    debugPrint('${rec.loggerName}>${rec.level.name}: ${rec.time}: ${rec.message}');
   });
 
   runApp(const MyApp());
@@ -24,6 +23,7 @@ class MyApp extends StatefulWidget {
 }
 
 class _MyAppState extends State<MyApp> {
+  final log = Logger('ExampleApp');
   final buttonTexts = ['Download', 'Cancel', 'Pause', 'Resume', 'Reset'];
 
   ButtonState buttonState = ButtonState.download;
@@ -39,7 +39,8 @@ class _MyAppState extends State<MyApp> {
     FileDownloader()
         .registerCallbacks(
             taskStatusCallback: myDownloadStatusCallback,
-            taskProgressCallback: myDownloadProgressCallback)
+            taskProgressCallback: myDownloadProgressCallback,
+            taskNotificationTapCallback: myNotificationTapCallback)
         .configureNotification(
             running: TaskNotification(
                 'Download {filename}', 'File: {filename} - {progress}'),
@@ -85,6 +86,11 @@ class _MyAppState extends State<MyApp> {
   /// Adds an update object to the stream that the main UI listens to
   void myDownloadProgressCallback(Task task, double progress) {
     updateStream.add(DownloadProgressIndicatorUpdate(task.filename, progress));
+  }
+
+  /// Process the user tapping on a notification by printing a message
+  void myNotificationTapCallback(Task task, NotificationType notificationType) {
+    debugPrint('Tapped notification $notificationType}');
   }
 
   @override

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -129,7 +129,7 @@ class _MyAppState extends State<MyApp> {
                     ),
                     Center(
                         child: ElevatedButton(
-                      onPressed: processButtonPress,
+                      onPressed: processFileOpen,
                       child: Text(
                         buttonTexts[buttonState.index],
                         style: Theme.of(context)
@@ -195,6 +195,16 @@ class _MyAppState extends State<MyApp> {
     if (mounted) {
       setState(() {});
     }
+  }
+
+  Future<void> processFileOpen() async {
+    var task = DownloadTask(url: 'https://google.com', baseDirectory: BaseDirectory.applicationDocuments, filename: 'google.txt');
+    final result = await FileDownloader().download(task);
+    print(result);
+    final filename = await FileDownloader().moveToSharedStorage(task, SharedStorage.external);
+    print(filename);
+    var success = await FileDownloader().openFile(filePath: filename);
+    print(success);
   }
 }
 

--- a/ios/Classes/Notifications.swift
+++ b/ios/Classes/Notifications.swift
@@ -26,6 +26,7 @@ struct NotificationConfig : Codable {
     let error: NotificationContents?
     let paused: NotificationContents?
     let progressBar: Bool
+    let tapOpensFile: Bool
 }
 
 enum NotificationType : Int {

--- a/ios/Classes/Notifications.swift
+++ b/ios/Classes/Notifications.swift
@@ -73,7 +73,7 @@ func updateNotification(task: Task, notificationType: NotificationType, notifica
             "notificationConfig": jsonStringFor(notificationConfig: notificationConfig!) ?? "",
             "notificationType": notificationType.rawValue
         ]
-        addActionButtons(task: task, notificationType: notificationType, content: content, notificationConfig: notificationConfig!)
+        addNotificationActions(task: task, notificationType: notificationType, content: content, notificationConfig: notificationConfig!)
         let request = UNNotificationRequest(identifier: task.taskId,
                                             content: content, trigger: nil)
         let notificationCenter = UNUserNotificationCenter.current()
@@ -88,7 +88,7 @@ func updateNotification(task: Task, notificationType: NotificationType, notifica
 /// Add action buttons to the notification
 ///
 /// Which button(s) depends on the [notificationType]. Action buttons are defined when defining the notification categories
-func addActionButtons(task: Task, notificationType: NotificationType, content: UNMutableNotificationContent, notificationConfig: NotificationConfig) {
+func addNotificationActions(task: Task, notificationType: NotificationType, content: UNMutableNotificationContent, notificationConfig: NotificationConfig) {
     switch notificationType {
     case .running:
         content.categoryIdentifier = Downloader.taskIdsThatCanResume.contains(task.taskId) && notificationConfig.paused != nil ? NotificationCategory.runningWithPause.rawValue : NotificationCategory.runningWithoutPause.rawValue

--- a/ios/Classes/OpenFile.swift
+++ b/ios/Classes/OpenFile.swift
@@ -6,13 +6,20 @@
 //
 
 import Foundation
+import MobileCoreServices
 
 ///
-func doOpenFile(filePath: String) -> Bool {
+func doOpenFile(filePath: String, mimeType: String?) -> Bool {
     let fileUrl = NSURL(fileURLWithPath: filePath)
     let documentInteractionController = UIDocumentInteractionController(url: fileUrl as URL)
     let delegate = DocumentInteractionControllerDelegate()
     documentInteractionController.delegate = delegate
+    if (mimeType != nil) {
+        if let uti = UTTypeCreatePreferredIdentifierForTag(kUTTagClassMIMEType, mimeType! as NSString, nil)?.takeRetainedValue()
+        {
+            documentInteractionController.uti = uti as String
+        }
+    }
     guard let view = UIApplication.shared.delegate?.window??.rootViewController?.view
     else {
         return false

--- a/ios/Classes/OpenFile.swift
+++ b/ios/Classes/OpenFile.swift
@@ -1,0 +1,32 @@
+//
+//  OpenFile.swift
+//  background_downloader
+//
+//  Created on 4/27/23.
+//
+
+import Foundation
+
+///
+func doOpenFile(filePath: String) -> Bool {
+    let fileUrl = NSURL(fileURLWithPath: filePath)
+    let documentInteractionController = UIDocumentInteractionController(url: fileUrl as URL)
+    let delegate = DocumentInteractionControllerDelegate()
+    documentInteractionController.delegate = delegate
+    guard let view = UIApplication.shared.delegate?.window??.rootViewController?.view
+    else {
+        return false
+    }
+    if !documentInteractionController.presentPreview(animated: true) {
+        documentInteractionController.presentOpenInMenu(from: view.bounds, in: view, animated: true)
+        return true
+    }
+    return true
+}
+
+class DocumentInteractionControllerDelegate: NSObject, UIDocumentInteractionControllerDelegate {
+    
+    func documentInteractionControllerViewControllerForPreview(_ controller: UIDocumentInteractionController) -> UIViewController {
+        return (UIApplication.shared.delegate?.window??.rootViewController)!
+    }
+}

--- a/ios/Classes/TaskFunctions.swift
+++ b/ios/Classes/TaskFunctions.swift
@@ -46,6 +46,15 @@ func isFinalState(status: TaskStatus) -> Bool {
     return !isNotFinalState(status: status)
 }
 
+/// Returns the filePath associated with this task, or nil
+func filePath(for task: Task) -> String? {
+    guard let directory = try? directoryForTask(task: task)
+    else {
+        return nil
+    }
+    return directory.appendingPathComponent(task.filename).path
+}
+
 /// Processes a change in status for the task
 ///
 /// Sends status update via the background channel to Dart, if requested

--- a/ios/Classes/TaskFunctions.swift
+++ b/ios/Classes/TaskFunctions.swift
@@ -47,7 +47,7 @@ func isFinalState(status: TaskStatus) -> Bool {
 }
 
 /// Returns the filePath associated with this task, or nil
-func filePath(for task: Task) -> String? {
+func getFilePath(for task: Task) -> String? {
     guard let directory = try? directoryForTask(task: task)
     else {
         return nil

--- a/lib/src/base_downloader.dart
+++ b/lib/src/base_downloader.dart
@@ -365,6 +365,17 @@ abstract class BaseDownloader {
     return Future.value(null);
   }
 
+  /// Open the file represented by [task] or [filePath] using the application
+  /// available on the platform.
+  ///
+  /// [mimeType] may override the mimetype derived from the file extension,
+  /// though implementation depends on the platform and may not always work.
+  ///
+  /// Returns true if an application was launched successfully
+  ///
+  /// Precondition: either task or filename is not null
+  Future<bool> openFile(Task? task, String? filePath, String? mimeType);
+
   /// Stores modified [modifiedTask] in local storage if [Task.group]
   /// or [Task.updates] fields differ from [originalTask]
   ///

--- a/lib/src/base_downloader.dart
+++ b/lib/src/base_downloader.dart
@@ -40,6 +40,9 @@ abstract class BaseDownloader {
   /// Registered [TaskProgressCallback] for each group
   final groupProgressCallbacks = <String, TaskProgressCallback>{};
 
+  /// Registered [TaskNotificationTapCallback] for each group
+  final groupNotificationTapCallbacks = <String, TaskNotificationTapCallback>{};
+
   /// StreamController for [TaskUpdate] updates
   var updates = StreamController<TaskUpdate>();
 
@@ -468,6 +471,27 @@ abstract class BaseDownloader {
   /// Process progress update coming from Downloader to client listener
   void processProgressUpdate(Task task, double progress) {
     _emitProgressUpdate(task, progress);
+  }
+
+  /// Process user tapping on a notification
+  ///
+  /// Because a notification tap may cause the app to start from scratch, we
+  /// allow a few retries with backoff to let the app register a callback
+  Future<void> processNotificationTap(
+      Task task, NotificationType notificationType) async {
+    var retries = 0;
+    var success = false;
+    while (retries < 5 && !success) {
+      final notificationTapCallback = groupNotificationTapCallbacks[task.group];
+      if (notificationTapCallback != null) {
+        notificationTapCallback(task, notificationType);
+        success = true;
+      } else {
+        await Future.delayed(
+            Duration(milliseconds: 100 * pow(2, retries).round()));
+        retries++;
+      }
+    }
   }
 
   /// Emits the status update for this task to its callback or listener, and

--- a/lib/src/desktop_downloader.dart
+++ b/lib/src/desktop_downloader.dart
@@ -273,6 +273,22 @@ class DesktopDownloader extends BaseDownloader {
   }
 
   @override
+  Future<bool> openFile(Task? task, String? filePath, String? mimeType) async {
+    final executable = Platform.isLinux
+        ? 'xdg-open'
+        : Platform.isMacOS
+            ? 'open'
+            : 'start';
+    filePath ??= await task!.filePath();
+    final result =
+        await Process.run(executable, [filePath], runInShell: true);
+    if (result.exitCode != 0) {
+      _log.fine('openFile command $executable returned exit code ${result.exitCode}');
+    }
+    return result.exitCode == 0;
+  }
+
+  @override
   void destroy() {
     super.destroy();
     _queue.clear();

--- a/lib/src/desktop_downloader.dart
+++ b/lib/src/desktop_downloader.dart
@@ -280,10 +280,14 @@ class DesktopDownloader extends BaseDownloader {
             ? 'open'
             : 'start';
     filePath ??= await task!.filePath();
-    final result =
-        await Process.run(executable, [filePath], runInShell: true);
+    if (!await File(filePath).exists()) {
+      _log.fine('File to open does not exist: $filePath');
+      return false;
+    }
+    final result = await Process.run(executable, [filePath], runInShell: true);
     if (result.exitCode != 0) {
-      _log.fine('openFile command $executable returned exit code ${result.exitCode}');
+      _log.fine(
+          'openFile command $executable returned exit code ${result.exitCode}');
     }
     return result.exitCode == 0;
   }

--- a/lib/src/file_downloader.dart
+++ b/lib/src/file_downloader.dart
@@ -575,6 +575,20 @@ class FileDownloader {
       _downloader.moveToSharedStorage(
           filePath, destination, directory, mimeType);
 
+  /// Open the file represented by [task] or [filePath] using the application
+  /// available on the platform.
+  ///
+  /// [mimeType] may override the mimetype derived from the file extension,
+  /// though implementation depends on the platform and may not always work.
+  ///
+  /// Returns true if an application was launched successfully
+  Future<bool> openFile({Task? task, String? filePath, String? mimeType}) {
+    assert(task != null || filePath != null, 'Task or filePath must be set');
+    assert(!(task != null && filePath != null),
+        'Either task or filePath must be set, not both');
+    return _downloader.openFile(task, filePath, mimeType);
+  }
+
   /// Destroy the [FileDownloader]. Subsequent use requires initialization
   void destroy() {
     _batches.clear();

--- a/lib/src/file_downloader.dart
+++ b/lib/src/file_downloader.dart
@@ -65,14 +65,11 @@ class FileDownloader {
   /// not have a registered callback
   Stream<TaskUpdate> get updates => _downloader.updates.stream;
 
-  /// Register status or progress callbacks to monitor download progress.
+  /// Register status or progress callbacks to monitor download progress, and
+  /// TaskNotificationTapCallback to respond to user tapping a notification.
   ///
   /// Status callbacks are called only when the state changes, while
   /// progress callbacks are called to inform of intermediate progress.
-  ///
-  /// Different callbacks can be set for different groups, and the group
-  /// can be passed on with the [DownloadTask] to ensure the
-  /// appropriate callbacks are called for that group.
   ///
   /// Note that callbacks will be called based on a task's [updates]
   /// property, which defaults to status change callbacks only. To also get
@@ -80,11 +77,20 @@ class FileDownloader {
   /// set the task's [updates] property to [Updates.progress] or
   /// [Updates.statusAndProgress].
   ///
+  /// For notification callbacks, make sure your AndroidManifest includes
+  /// android:launchMode="singleTask" to ensure proper behavior when a
+  /// notification is tapped.
+  ///
+  /// Different callbacks can be set for different groups, and the group
+  /// can be passed on with the [DownloadTask] to ensure the
+  /// appropriate callbacks are called for that group.
+  ///
   /// The call returns the [FileDownloader] to make chaining easier
   FileDownloader registerCallbacks(
       {String group = defaultGroup,
       TaskStatusCallback? taskStatusCallback,
-      TaskProgressCallback? taskProgressCallback}) {
+      TaskProgressCallback? taskProgressCallback,
+      TaskNotificationTapCallback? taskNotificationTapCallback}) {
     assert(taskStatusCallback != null || (taskProgressCallback != null),
         'Must provide a TaskStatusCallback or a TaskProgressCallback, or both');
     if (taskStatusCallback != null) {
@@ -92,6 +98,10 @@ class FileDownloader {
     }
     if (taskProgressCallback != null) {
       _downloader.groupProgressCallbacks[group] = taskProgressCallback;
+    }
+    if (taskNotificationTapCallback != null) {
+      _downloader.groupNotificationTapCallbacks[group] =
+          taskNotificationTapCallback;
     }
     return this; // makes chaining calls easier
   }

--- a/lib/src/file_downloader.dart
+++ b/lib/src/file_downloader.dart
@@ -458,35 +458,39 @@ class FileDownloader {
 
   /// Configure notification for a single task
   FileDownloader configureNotificationForTask(Task task,
-      {TaskNotification? runningNotification,
-      TaskNotification? completeNotification,
-      TaskNotification? errorNotification,
-      TaskNotification? pausedNotification,
-      bool progressBar = false}) {
+      {TaskNotification? running,
+      TaskNotification? complete,
+      TaskNotification? error,
+      TaskNotification? paused,
+      bool progressBar = false,
+      bool tapOpensFile = false}) {
     _notificationConfigs.add(TaskNotificationConfig(
         taskOrGroup: task,
-        running: runningNotification,
-        complete: completeNotification,
-        error: errorNotification,
-        paused: pausedNotification,
-        progressBar: progressBar));
+        running: running,
+        complete: complete,
+        error: error,
+        paused: paused,
+        progressBar: progressBar,
+        tapOpensFile: tapOpensFile));
     return this;
   }
 
   /// Configure notification for a group of tasks
   FileDownloader configureNotificationForGroup(String group,
-      {TaskNotification? runningNotification,
-      TaskNotification? completeNotification,
-      TaskNotification? errorNotification,
-      TaskNotification? pausedNotification,
-      bool progressBar = false}) {
+      {TaskNotification? running,
+      TaskNotification? complete,
+      TaskNotification? error,
+      TaskNotification? paused,
+      bool progressBar = false,
+      bool tapOpensFile = false}) {
     _notificationConfigs.add(TaskNotificationConfig(
         taskOrGroup: group,
-        running: runningNotification,
-        complete: completeNotification,
-        error: errorNotification,
-        paused: pausedNotification,
-        progressBar: progressBar));
+        running: running,
+        complete: complete,
+        error: error,
+        paused: paused,
+        progressBar: progressBar,
+        tapOpensFile: tapOpensFile));
     return this;
   }
 
@@ -499,14 +503,16 @@ class FileDownloader {
       TaskNotification? complete,
       TaskNotification? error,
       TaskNotification? paused,
-      bool progressBar = false}) {
+      bool progressBar = false,
+      bool tapOpensFile = false}) {
     _notificationConfigs.add(TaskNotificationConfig(
         taskOrGroup: null,
         running: running,
         complete: complete,
         error: error,
         paused: paused,
-        progressBar: progressBar));
+        progressBar: progressBar,
+        tapOpensFile: tapOpensFile));
     return this;
   }
 

--- a/lib/src/models.dart
+++ b/lib/src/models.dart
@@ -132,6 +132,11 @@ typedef TaskStatusCallback = void Function(Task task, TaskStatus status);
 /// These constants are available as [progressFailed] etc
 typedef TaskProgressCallback = void Function(Task task, double progress);
 
+/// Signature for function you can register to be called when a notification
+/// is tapped by the user
+typedef TaskNotificationTapCallback = void Function(
+    Task task, NotificationType notificationType);
+
 /// A server Request
 ///
 /// An equality test on a [Request] is an equality test on the [url]
@@ -862,6 +867,10 @@ class ResumeData {
 
 /// Types of undelivered data that can be requested
 enum Undelivered { resumeData, statusUpdates, progressUpdates }
+
+/// Notification types, as configured in [TaskNotificationConfig] and passed
+/// on to [TaskNotificationTapCallback]
+enum NotificationType { running, complete, error, paused }
 
 /// Notification specification for a [Task]
 ///

--- a/lib/src/models.dart
+++ b/lib/src/models.dart
@@ -906,6 +906,7 @@ class TaskNotificationConfig {
   final TaskNotification? error;
   final TaskNotification? paused;
   final bool progressBar;
+  final bool tapOpensFile;
 
   TaskNotificationConfig(
       {this.taskOrGroup,
@@ -913,7 +914,8 @@ class TaskNotificationConfig {
       this.complete,
       this.error,
       this.paused,
-      this.progressBar = false}) {
+      this.progressBar = false,
+      this.tapOpensFile = false}) {
     assert(
         running != null || complete != null || error != null || paused != null,
         'At least one notification must be set');
@@ -922,11 +924,12 @@ class TaskNotificationConfig {
   /// Return JSON Map representing object, excluding the [taskOrGroup] field,
   /// as the JSON map is only required to pass along the config with a task
   Map<String, dynamic> toJsonMap() => {
-        "running": running?.toJsonMap(),
-        "complete": complete?.toJsonMap(),
-        "error": error?.toJsonMap(),
-        "paused": paused?.toJsonMap(),
-        "progressBar": progressBar
+        'running': running?.toJsonMap(),
+        'complete': complete?.toJsonMap(),
+        'error': error?.toJsonMap(),
+        'paused': paused?.toJsonMap(),
+        'progressBar': progressBar,
+        'tapOpensFile': tapOpensFile
       };
 }
 

--- a/lib/src/native_downloader.dart
+++ b/lib/src/native_downloader.dart
@@ -186,4 +186,14 @@ class NativeDownloader extends BaseDownloader {
           SharedStorage destination, String directory, String? mimeType) =>
       _channel.invokeMethod<String?>('moveToSharedStorage',
           [filePath, destination.index, directory, mimeType]);
+
+  @override
+  Future<bool> openFile(Task? task, String? filePath, String? mimeType) async {
+    final result = await _channel.invokeMethod<bool>('openFile', [
+      task != null ? jsonEncode(task.toJsonMap()) : null,
+      filePath,
+      mimeType
+    ]);
+    return result ?? false;
+  }
 }

--- a/lib/src/native_downloader.dart
+++ b/lib/src/native_downloader.dart
@@ -55,6 +55,11 @@ class NativeDownloader extends BaseDownloader {
           setResumeData(ResumeData(task, tempFilename, startByte));
           break;
 
+        case 'notificationTap':
+          final notificationType = NotificationType.values[args.last as int];
+          processNotificationTap(task, notificationType);
+          break;
+
         default:
           throw UnimplementedError(
               'Background channel method call ${call.method} not supported');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: background_downloader
 description: A multi-platform background file downloader and uploader. Define the task, enqueue and monitor progress
 
-version: 5.5.0
+version: 5.6.0
 repository: https://github.com/781flyingdutchman/background_downloader
 
 environment:


### PR DESCRIPTION
Fixes issue #36 
Adds handler for when the user taps a notification, and an `openFile` method to open a file using the platform-specific convention.

To handle notification taps, register a callback that takes `Task` and `NotificationType` as parameters:

```
FileDownloader().registerCallbacks(
            taskNotificationTapCallback: myNotificationTapCallback);
            
void myNotificationTapCallback(Task task, NotificationType notificationType) {
    print('Tapped notification $notificationType for taskId ${task.taskId}');
  }
```

To open a file, call `FileDownloader().openFile` and supply either a `Task` or a full `filePath` (but not both) and optionally a `mimeType` to assist the Platform in choosing the right application to use to open the file.
The file opening behavior is platform dependent, and while you should check the return value of the call to `openFile`, error checking is not fully consistent.

Note that on Android, files stored in the `BaseDirectory.applicationDocuments` cannot be opened. You need to download to a different base directory (e.g. `.applicationSupport`) or move the file to shared storage before attempting to open it.

If all you want to do on notification tap is to open the file, you can simplify the process by 
adding `tapOpensFile: true` to your call to `configureNotifications`, and you don't need to 
register a `taskNotificationTapCallback`.

