### PR TITLE
V6 - API clean up and bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 6.0.0
+
+Callbacks now have a single paramter TaskStatusUpdate or TaskProgressUpdate
+.download method and .upload method now result in a TaskStatusUpdate
+TaskStatusUpdate now has an exception field (if status is .failed)
+
+You can set the httpRequestMethod
+
+
 ## 5.6.0
 
 Adds handler for when the user taps a notification, and an `openFile` method to open a file using the platform-specific convention.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 5.4.5
+
+An invalid url in the `Task` now results in `false` being returned from the `enqueue` call on 
+all platforms. Previously, the behavior was inconsistent.
+
 ## 5.4.4
 
 Added optional properties to `UploadTask` related to multi-part uploads:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ TaskStatusUpdate now has an exception field (if status is .failed)
 
 You can set the httpRequestMethod
 
+TrackTasks: if no group is given, all tasks will be tracked (previously only tasks in the default group)
+
 
 ## 5.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,23 @@
 ## 6.0.0
 
-Callbacks now have a single paramter TaskStatusUpdate or TaskProgressUpdate
-.download method and .upload method now result in a TaskStatusUpdate
-TaskStatusUpdate now has an exception field (if status is .failed)
+Breaking changes:
+* The `TaskStatusCallback` and `TaskProgressCallback` now take a single argument (`TaskStatusUpdate` and `TaskProgressUpdate` respectively) instead of multiple arguments. This aligns the callback API with the `updates` listener API, and makes it easier to add data to an update in the future. For example, in this version we add an `exception` property to programmatically handle exceptions
+* Similarly, the `download` and `upload` methods now return a `TaskStatusUpdate` instead of a `TaskStatus`
+* For consistency, the `taskStatus` property of the `TaskRecord` (used to store task information in a persistent database) is renamed to `status`
+* The `trackTasks` method no longer takes a `group` argument, and starts tracking for all tasks, regardless of group. If you need tracking only for a specific group, call the new `trackTasksInGroup` method
 
-You can set the httpRequestMethod
+Other changes (non-breaking):
+* You can override the `httpRequestMethod` used for requests by setting it in the `Request`, `DownloadTask` or `UploadTask`. By default, requests and downloads use GET (unless `post` is set) and uploads use PUT
+* The `download`, `upload`, `downloadBatch` and `uploadBatch` methods now take an optional `onElapsedTime` callback that is called at regular intervals (defined by the optional `elapsedTimeInterval` which defaults to 5 seconds) with the time elapsed since the call was made. This can be used to trigger UI warnings (e.g. 'this is taking rather long') or to cancel the task if it does not complete within a desired time. For performance reasons the `elapsedTimeInterval` should not be set to a value less than one second, and this mechanism should not be used to indicate progress.
+* If a task fails, the `TaskStatusUpdate` will contain a `TaskException` that provides information about the type of exception (e.g. a `TaskFileSystemException` indicates an issue with storing or retrieving the file) and contains a `description` and (for `TaskHttpException` only) the `httpResponseCode`. If tasks are tracked, the  The following `TaskException` subtypes may occur:
+  - `TaskException` (general exception)
+  - `TaskFileSystemException` (issue retrieving or storing the file)
+  - `TaskUrlException` (issue with the url)
+  - `TaskConnectionException` (issue with the connection to the server)
+  - `TaskResumeException` (issue with pausing or resuming a task)
+  - `TaskHttpException` (issue with the HTTP connection, e.g. we received an error response from the server, captured in `httpResponseCode`)
 
-TrackTasks: if no group is given, all tasks will be tracked (previously only tasks in the default group)
-
+Fixed a few bugs.
 
 ## 5.6.0
 
@@ -29,8 +39,8 @@ The file opening behavior is platform dependent, and while you should check the 
 
 Note that on Android, files stored in the `BaseDirectory.applicationDocuments` cannot be opened. You need to download to a different base directory (e.g. `.applicationSupport`) or move the file to shared storage before attempting to open it.
 
-If all you want to do on notification tap is to open the file, you can simplify the process by 
-adding `tapOpensFile: true` to your call to `configureNotifications`, and you don't need to 
+If all you want to do on notification tap is to open the file, you can simplify the process by
+adding `tapOpensFile: true` to your call to `configureNotifications`, and you don't need to
 register a `taskNotificationTapCallback`.
 
 ## 5.5.0

--- a/README.md
+++ b/README.md
@@ -378,6 +378,14 @@ If the `requiresWiFi` field of a `Task` is set to true, the task won't start unl
 
 ### UploadTask
 
+#### File field
+
+Set `fileField` to the field name the server expects for the file portion of a multi-part upload. Defaults to "file".
+
+#### Mime type
+
+Set `mimeType` to the MIME type of the file to be uploaded. By default the MIME type is derived from the filename extension, e.g. a .txt file has MIME type `text/plain`.
+
 #### Form fields
 
 Set `fields` to a `Map<String, String>` of name/value pairs to upload as "form fields" along with the file.

--- a/android/src/main/kotlin/com/bbflight/background_downloader/BackgroundDownloaderPlugin.kt
+++ b/android/src/main/kotlin/com/bbflight/background_downloader/BackgroundDownloaderPlugin.kt
@@ -49,7 +49,7 @@ import kotlin.math.pow
  * [TaskWorker]
  */
 class BackgroundDownloaderPlugin : FlutterPlugin, MethodCallHandler, ActivityAware,
-        PluginRegistry.RequestPermissionsResultListener {
+    PluginRegistry.RequestPermissionsResultListener {
     companion object {
         const val TAG = "BackgroundDownloader"
         const val keyTasksMap = "com.bbflight.background_downloader.taskMap"
@@ -78,12 +78,12 @@ class BackgroundDownloaderPlugin : FlutterPlugin, MethodCallHandler, ActivityAwa
          * Enqueue a WorkManager task based on the provided parameters
          */
         suspend fun doEnqueue(
-                context: Context,
-                taskJsonMapString: String,
-                notificationConfigJsonString: String?,
-                tempFilePath: String?,
-                startByte: Long?,
-                initialDelayMillis: Long = 0
+            context: Context,
+            taskJsonMapString: String,
+            notificationConfigJsonString: String?,
+            tempFilePath: String?,
+            startByte: Long?,
+            initialDelayMillis: Long = 0
         ): Boolean {
             val task = Task(gson.fromJson(taskJsonMapString, jsonMapType))
             Log.i(TAG, "Enqueuing task with id ${task.taskId}")
@@ -98,15 +98,15 @@ class BackgroundDownloaderPlugin : FlutterPlugin, MethodCallHandler, ActivityAwa
             }
             if (tempFilePath != null && startByte != null) {
                 dataBuilder.putString(keyTempFilename, tempFilePath)
-                        .putLong(keyStartByte, startByte)
+                    .putLong(keyStartByte, startByte)
             }
             val data = dataBuilder.build()
             val constraints = Constraints.Builder().setRequiredNetworkType(
-                    if (task.requiresWiFi) NetworkType.UNMETERED else NetworkType.CONNECTED
+                if (task.requiresWiFi) NetworkType.UNMETERED else NetworkType.CONNECTED
             ).build()
             val requestBuilder = OneTimeWorkRequestBuilder<TaskWorker>().setInputData(data)
-                    .setConstraints(constraints).addTag(TAG).addTag("taskId=${task.taskId}")
-                    .addTag("group=${task.group}")
+                .setConstraints(constraints).addTag(TAG).addTag("taskId=${task.taskId}")
+                .addTag("group=${task.group}")
             if (initialDelayMillis != 0L) {
                 requestBuilder.setInitialDelay(initialDelayMillis, TimeUnit.MILLISECONDS)
             }
@@ -119,7 +119,7 @@ class BackgroundDownloaderPlugin : FlutterPlugin, MethodCallHandler, ActivityAwa
                 val prefs = PreferenceManager.getDefaultSharedPreferences(context)
                 if (initialDelayMillis == 0L) {
                     TaskWorker.processStatusUpdate(
-                            task, TaskStatus.enqueued, prefs
+                        task, TaskStatus.enqueued, prefs
                     )
                 } else {
                     delay(min(100L, initialDelayMillis))
@@ -127,8 +127,8 @@ class BackgroundDownloaderPlugin : FlutterPlugin, MethodCallHandler, ActivityAwa
                 }
             } catch (e: Throwable) {
                 Log.w(
-                        TAG,
-                        "Unable to start background request for taskId ${task.taskId} in operation: $operation"
+                    TAG,
+                    "Unable to start background request for taskId ${task.taskId} in operation: $operation"
                 )
                 return false
             }
@@ -137,7 +137,7 @@ class BackgroundDownloaderPlugin : FlutterPlugin, MethodCallHandler, ActivityAwa
                 val prefs = PreferenceManager.getDefaultSharedPreferences(context)
                 val jsonString = prefs.getString(keyTasksMap, "{}")
                 val tasksMap =
-                        gson.fromJson<Map<String, Any>>(jsonString, jsonMapType).toMutableMap()
+                    gson.fromJson<Map<String, Any>>(jsonString, jsonMapType).toMutableMap()
                 tasksMap[task.taskId] = gson.toJson(task.toJsonMap())
                 val editor = prefs.edit()
                 editor.putString(keyTasksMap, gson.toJson(tasksMap))
@@ -152,7 +152,7 @@ class BackgroundDownloaderPlugin : FlutterPlugin, MethodCallHandler, ActivityAwa
          * The [taskId] must be managed by the [workManager]
          */
         suspend fun cancelActiveTaskWithId(
-                context: Context, taskId: String, workManager: WorkManager
+            context: Context, taskId: String, workManager: WorkManager
         ): Boolean {
             val workInfos = withContext(Dispatchers.IO) {
                 workManager.getWorkInfosByTag("taskId=$taskId").get()
@@ -171,7 +171,7 @@ class BackgroundDownloaderPlugin : FlutterPlugin, MethodCallHandler, ActivityAwa
                         val taskJsonMap = tasksMap[taskId] as String?
                         if (taskJsonMap != null) {
                             val task = Task(
-                                    gson.fromJson(taskJsonMap, jsonMapType)
+                                gson.fromJson(taskJsonMap, jsonMapType)
                             )
                             TaskWorker.processStatusUpdate(task, TaskStatus.canceled, prefs)
                         } else {
@@ -237,12 +237,12 @@ class BackgroundDownloaderPlugin : FlutterPlugin, MethodCallHandler, ActivityAwa
             // and per https://github.com/firebase/flutterfire/issues/9689 other
             // plugins can create multiple instances of the plugin
             backgroundChannel = MethodChannel(
-                    flutterPluginBinding.binaryMessenger,
-                    "com.bbflight.background_downloader.background"
+                flutterPluginBinding.binaryMessenger,
+                "com.bbflight.background_downloader.background"
             )
         }
         channel = MethodChannel(
-                flutterPluginBinding.binaryMessenger, "com.bbflight.background_downloader"
+            flutterPluginBinding.binaryMessenger, "com.bbflight.background_downloader"
         )
         channel?.setMethodCallHandler(this)
         // set context and register notification broadcast receivers
@@ -299,7 +299,7 @@ class BackgroundDownloaderPlugin : FlutterPlugin, MethodCallHandler, ActivityAwa
                 "moveToSharedStorage" -> methodMoveToSharedStorage(call, result)
                 "openFile" -> methodOpenFile(call, result)
                 "forceFailPostOnBackgroundChannel" -> methodForceFailPostOnBackgroundChannel(
-                        call, result
+                    call, result
                 )
 
                 else -> result.notImplemented()
@@ -330,13 +330,13 @@ class BackgroundDownloaderPlugin : FlutterPlugin, MethodCallHandler, ActivityAwa
             startByte = null
         }
         result.success(
-                doEnqueue(
-                        applicationContext,
-                        taskJsonMapString,
-                        notificationConfigJsonString,
-                        tempFilePath,
-                        startByte
-                )
+            doEnqueue(
+                applicationContext,
+                taskJsonMapString,
+                notificationConfigJsonString,
+                tempFilePath,
+                startByte
+            )
         )
     }
 
@@ -351,7 +351,7 @@ class BackgroundDownloaderPlugin : FlutterPlugin, MethodCallHandler, ActivityAwa
         var counter = 0
         val workManager = WorkManager.getInstance(applicationContext)
         val workInfos = workManager.getWorkInfosByTag(TAG).get()
-                .filter { !it.state.isFinished && it.tags.contains("group=$group") }
+            .filter { !it.state.isFinished && it.tags.contains("group=$group") }
         for (workInfo in workInfos) {
             workManager.cancelWorkById(workInfo.id)
             counter++
@@ -367,7 +367,7 @@ class BackgroundDownloaderPlugin : FlutterPlugin, MethodCallHandler, ActivityAwa
         val group = call.arguments as String
         val workManager = WorkManager.getInstance(applicationContext)
         val workInfos = workManager.getWorkInfosByTag(TAG).get()
-                .filter { !it.state.isFinished && it.tags.contains("group=$group") }
+            .filter { !it.state.isFinished && it.tags.contains("group=$group") }
         val tasksAsListOfJsonStrings = mutableListOf<String>()
         prefsLock.read {
             val prefs = PreferenceManager.getDefaultSharedPreferences(applicationContext)
@@ -480,32 +480,32 @@ class BackgroundDownloaderPlugin : FlutterPlugin, MethodCallHandler, ActivityAwa
         val mimeType = args[3] as String?
         // first check and potentially ask for permissions
         if (Build.VERSION.SDK_INT < 30 && ActivityCompat.checkSelfPermission(
-                        applicationContext, Manifest.permission.WRITE_EXTERNAL_STORAGE
-                ) != PackageManager.PERMISSION_GRANTED
+                applicationContext, Manifest.permission.WRITE_EXTERNAL_STORAGE
+            ) != PackageManager.PERMISSION_GRANTED
         ) {
             if (activity != null) {
                 activity?.requestPermissions(
-                        arrayOf(Manifest.permission.WRITE_EXTERNAL_STORAGE),
-                        externalStoragePermissionRequestCode
+                    arrayOf(Manifest.permission.WRITE_EXTERNAL_STORAGE),
+                    externalStoragePermissionRequestCode
                 )
                 externalStoragePermissionCompleter.thenApplyAsync {
                     result.success(
-                            moveToSharedStorage(
-                                    applicationContext, filePath, destination, directory, mimeType
-                            )
+                        moveToSharedStorage(
+                            applicationContext, filePath, destination, directory, mimeType
+                        )
                     )
                 }
                 return
             }
         }
         result.success(
-                moveToSharedStorage(
-                        applicationContext,
-                        filePath,
-                        destination,
-                        directory,
-                        mimeType
-                )
+            moveToSharedStorage(
+                applicationContext,
+                filePath,
+                destination,
+                directory,
+                mimeType
+            )
         )
     }
 
@@ -519,7 +519,7 @@ class BackgroundDownloaderPlugin : FlutterPlugin, MethodCallHandler, ActivityAwa
         val args = call.arguments as List<*>
         val taskJsonMapString = args[0] as String?
         val task = if (taskJsonMapString != null) Task(
-                Gson().fromJson(taskJsonMapString, jsonMapType)
+            Gson().fromJson(taskJsonMapString, jsonMapType)
         ) else null
         val filePath = args[1] as String? ?: task!!.filePath(applicationContext)
         val mimeType = args[2] as String? ?: getMimeType(filePath)
@@ -556,9 +556,9 @@ class BackgroundDownloaderPlugin : FlutterPlugin, MethodCallHandler, ActivityAwa
     private fun handleIntent(intent: Intent?): Boolean {
         if (intent != null && intent.action == NotificationRcvr.actionTap) {
             val taskJsonMapString =
-                    intent.extras?.getString(NotificationRcvr.bundleTask)
+                intent.extras?.getString(NotificationRcvr.bundleTask)
             val notificationTypeOrdinal =
-                    intent.getIntExtra(NotificationRcvr.bundleNotificationType, 0)
+                intent.getIntExtra(NotificationRcvr.bundleNotificationType, 0)
             scope?.launch {
                 var retries = 0
                 var success = false
@@ -566,8 +566,8 @@ class BackgroundDownloaderPlugin : FlutterPlugin, MethodCallHandler, ActivityAwa
                     try {
                         if (backgroundChannel != null) {
                             backgroundChannel?.invokeMethod(
-                                    "notificationTap",
-                                    listOf(taskJsonMapString, notificationTypeOrdinal)
+                                "notificationTap",
+                                listOf(taskJsonMapString, notificationTypeOrdinal)
                             )
                             success = true
                         }
@@ -583,11 +583,11 @@ class BackgroundDownloaderPlugin : FlutterPlugin, MethodCallHandler, ActivityAwa
             if (notificationTypeOrdinal == NotificationType.complete.ordinal) {
                 val task = Task(gson.fromJson(taskJsonMapString, jsonMapType))
                 val notificationConfigJsonString =
-                        intent.extras?.getString(NotificationRcvr.bundleNotificationConfig)
+                    intent.extras?.getString(NotificationRcvr.bundleNotificationConfig)
                 val notificationConfig =
-                        if (notificationConfigJsonString != null) gson.fromJson(
-                                notificationConfigJsonString, NotificationConfig::class.java
-                        ) else null
+                    if (notificationConfigJsonString != null) gson.fromJson(
+                        notificationConfigJsonString, NotificationConfig::class.java
+                    ) else null
                 if (notificationConfig?.tapOpensFile == true && activity != null) {
                     val filePath = task.filePath(activity!!)
                     doOpenFile(activity!!, filePath, getMimeType(filePath))
@@ -624,10 +624,10 @@ class BackgroundDownloaderPlugin : FlutterPlugin, MethodCallHandler, ActivityAwa
     }
 
     override fun onRequestPermissionsResult(
-            requestCode: Int, permissions: Array<out String>, grantResults: IntArray
+        requestCode: Int, permissions: Array<out String>, grantResults: IntArray
     ): Boolean {
         val granted =
-                (grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED)
+            (grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED)
         return when (requestCode) {
             notificationPermissionRequestCode -> {
                 requestingNotificationPermission = false

--- a/android/src/main/kotlin/com/bbflight/background_downloader/BackgroundDownloaderPlugin.kt
+++ b/android/src/main/kotlin/com/bbflight/background_downloader/BackgroundDownloaderPlugin.kt
@@ -8,6 +8,7 @@ import android.content.IntentFilter
 import android.content.pm.PackageManager
 import android.os.Build
 import android.util.Log
+import android.util.Patterns
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.preference.PreferenceManager
@@ -82,6 +83,10 @@ class BackgroundDownloaderPlugin : FlutterPlugin, MethodCallHandler, ActivityAwa
         ): Boolean {
             val task = Task(gson.fromJson(taskJsonMapString, jsonMapType))
             Log.i(TAG, "Enqueuing task with id ${task.taskId}")
+            if (!Patterns.WEB_URL.matcher(task.url).matches()) {
+                Log.i(TAG, "Invalid url: ${task.url}")
+                return false
+            }
             canceledTaskIds.remove(task.taskId)
             val dataBuilder = Data.Builder().putString(TaskWorker.keyTask, taskJsonMapString)
             if (notificationConfigJsonString != null) {

--- a/android/src/main/kotlin/com/bbflight/background_downloader/Models.kt
+++ b/android/src/main/kotlin/com/bbflight/background_downloader/Models.kt
@@ -38,6 +38,7 @@ class Task(
     val url: String,
     val filename: String,
     val headers: Map<String, String>,
+    val httpRequestMethod: String,
     val post: String?,
     val fileField: String,
     val mimeType: String,
@@ -62,6 +63,7 @@ class Task(
         url = jsonMap["url"] as String? ?: "",
         filename = jsonMap["filename"] as String? ?: "",
         headers = jsonMap["headers"] as Map<String, String>? ?: mutableMapOf<String, String>(),
+        httpRequestMethod = jsonMap["httpRequestMethod"] as String? ?: "GET",
         post = jsonMap["post"] as String?,
         fileField = jsonMap["fileField"] as String? ?: "",
         mimeType = jsonMap["mimeType"] as String? ?: "",
@@ -87,6 +89,7 @@ class Task(
             "url" to url,
             "filename" to filename,
             "headers" to headers,
+            "httpRequestMethod" to httpRequestMethod,
             "post" to post,
             "fileField" to fileField,
             "mimeType" to mimeType,
@@ -153,7 +156,7 @@ class Task(
     }
 
     override fun toString(): String {
-        return "Task(taskId='$taskId', url='$url', filename='$filename', headers=$headers, post=$post, fileField='$fileField', mimeType='$mimeType', fields=$fields, directory='$directory', baseDirectory=$baseDirectory, group='$group', updates=$updates, requiresWiFi=$requiresWiFi, retries=$retries, retriesRemaining=$retriesRemaining, allowPause=$allowPause, metaData='$metaData', creationTime=$creationTime, taskType='$taskType')"
+        return "Task(taskId='$taskId', url='$url', filename='$filename', headers=$headers, httpRequestMethod=$httpRequestMethod, post=$post, fileField='$fileField', mimeType='$mimeType', fields=$fields, directory='$directory', baseDirectory=$baseDirectory, group='$group', updates=$updates, requiresWiFi=$requiresWiFi, retries=$retries, retriesRemaining=$retriesRemaining, allowPause=$allowPause, metaData='$metaData', creationTime=$creationTime, taskType='$taskType')"
     }
 
 
@@ -225,12 +228,16 @@ enum class ExceptionType(val typeString: String) {
 }
 
 /**
-* Contains error information associated with a failed [Task]
-*
-* The [type] categorizes the exception, used to create the appropriate subclass on the Flutter side
-* The [httpResponseCode] is only valid if >0 and may offer details about the
-* nature of the error
-* The [description] is typically taken from the platform-generated
-* error message, or from the plugin. The localization is undefined
-*/
-class TaskException(val type: ExceptionType, val httpResponseCode: Int = -1, val description: String = "")
+ * Contains error information associated with a failed [Task]
+ *
+ * The [type] categorizes the exception, used to create the appropriate subclass on the Flutter side
+ * The [httpResponseCode] is only valid if >0 and may offer details about the
+ * nature of the error
+ * The [description] is typically taken from the platform-generated
+ * error message, or from the plugin. The localization is undefined
+ */
+class TaskException(
+    val type: ExceptionType,
+    val httpResponseCode: Int = -1,
+    val description: String = ""
+)

--- a/android/src/main/kotlin/com/bbflight/background_downloader/Models.kt
+++ b/android/src/main/kotlin/com/bbflight/background_downloader/Models.kt
@@ -151,6 +151,12 @@ class Task(
                 "$baseDirPath/${directory}/${filename}"
         }
     }
+
+    override fun toString(): String {
+        return "Task(taskId='$taskId', url='$url', filename='$filename', headers=$headers, post=$post, fileField='$fileField', mimeType='$mimeType', fields=$fields, directory='$directory', baseDirectory=$baseDirectory, group='$group', updates=$updates, requiresWiFi=$requiresWiFi, retries=$retries, retriesRemaining=$retriesRemaining, allowPause=$allowPause, metaData='$metaData', creationTime=$creationTime, taskType='$taskType')"
+    }
+
+
 }
 
 /** Defines a set of possible states which a [Task] can be in.

--- a/android/src/main/kotlin/com/bbflight/background_downloader/Models.kt
+++ b/android/src/main/kotlin/com/bbflight/background_downloader/Models.kt
@@ -151,3 +151,34 @@ class ResumeData(val task: Task, val data: String, val requiredStartByte: Long) 
         )
     }
 }
+
+enum class ErrorType {
+    /// Invalid HTTP response
+    httpResponse,
+
+    /// Could not save or find file, or create directory
+    fileSystem,
+
+    /// URL incorrect
+    url,
+
+    /// Connection problem, eg host not found, timeout
+    connection,
+
+    /// Could not resume or pause task
+    resume,
+
+    /// General error
+    general
+}
+
+/**
+* Contains error information associated with a failed [Task]
+*
+* The [type] categorizes the error
+* The [httpResponseCode] is only valid if >0 and may offer details about the
+* nature of the error
+* The [description] is typically taken from the platform-generated
+* error message, or from the plugin. The localization is undefined
+*/
+class TaskError(val type: ErrorType, val httpResponseCode: Int = -1, val description: String = "")

--- a/android/src/main/kotlin/com/bbflight/background_downloader/Models.kt
+++ b/android/src/main/kotlin/com/bbflight/background_downloader/Models.kt
@@ -187,33 +187,44 @@ class ResumeData(val task: Task, val data: String, val requiredStartByte: Long) 
     }
 }
 
-enum class ErrorType {
-    /// Invalid HTTP response
-    httpResponse,
+
+/**
+ * The type of a [TaskException]
+ *
+ * Exceptions are handled differently on the Kotlin side because they are only a vehicle to message
+ * to the Flutter side. An exception class hierarchy is therefore not required in Kotlin, and the
+ * single [TaskException] class has a field for the [TaskException.type] of exception, as well as all possible
+ * exception fields.
+ * The [TaskException.type] (as a String using the enum's [ExceptionType.typeString]) is used on the
+ * Flutter side to create the approrpriate Exception subclass.
+ */
+enum class ExceptionType(val typeString: String) {
+    /// General error
+    general("TaskException"),
 
     /// Could not save or find file, or create directory
-    fileSystem,
+    fileSystem("TaskFileSystemException"),
 
     /// URL incorrect
-    url,
+    url("TaskUrlException"),
 
     /// Connection problem, eg host not found, timeout
-    connection,
+    connection("TaskConnectionException"),
 
     /// Could not resume or pause task
-    resume,
+    resume("TaskResumeException"),
 
-    /// General error
-    general
+    /// Invalid HTTP response
+    httpResponse("TaskHttpException")
 }
 
 /**
 * Contains error information associated with a failed [Task]
 *
-* The [type] categorizes the error
+* The [type] categorizes the exception, used to create the appropriate subclass on the Flutter side
 * The [httpResponseCode] is only valid if >0 and may offer details about the
 * nature of the error
 * The [description] is typically taken from the platform-generated
 * error message, or from the plugin. The localization is undefined
 */
-class TaskError(val type: ErrorType, val httpResponseCode: Int = -1, val description: String = "")
+class TaskException(val type: ExceptionType, val httpResponseCode: Int = -1, val description: String = "")

--- a/android/src/main/kotlin/com/bbflight/background_downloader/OpenFile.kt
+++ b/android/src/main/kotlin/com/bbflight/background_downloader/OpenFile.kt
@@ -15,7 +15,9 @@ fun doOpenFile(activity: Activity, filePath: String, mimeType: String): Boolean 
     try {
         if (BackgroundDownloaderPlugin.activity != null) {
             val contentUri = getUriForFile(
-                activity, activity.packageName + ".com.bbflight.background_downloader.fileprovider", File(filePath)
+                activity,
+                activity.packageName + ".com.bbflight.background_downloader.fileprovider",
+                File(filePath)
             )
             intent.setDataAndType(contentUri, mimeType)
             intent.addFlags(

--- a/android/src/main/kotlin/com/bbflight/background_downloader/SharedStorage.kt
+++ b/android/src/main/kotlin/com/bbflight/background_downloader/SharedStorage.kt
@@ -28,7 +28,11 @@ val trailingPathSeparatorRegEx = Regex("""/$""")
  * If successful, the original file will have been deleted
  */
 fun moveToSharedStorage(
-    context: Context, filePath: String, destination: SharedStorage, directory: String, mimeType: String?
+    context: Context,
+    filePath: String,
+    destination: SharedStorage,
+    directory: String,
+    mimeType: String?
 ): String? {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
         return moveToPublicDirectory(filePath, destination, directory)
@@ -197,7 +201,7 @@ private fun getRelativePath(destination: SharedStorage, directory: String): Stri
 fun getMimeType(fileName: String): String {
     val extension = fileName.substringAfterLast(".", "")
     return MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension)
-            ?: "application/octet-stream"
+        ?: "application/octet-stream"
 }
 
 /**

--- a/android/src/main/kotlin/com/bbflight/background_downloader/TaskWorker.kt
+++ b/android/src/main/kotlin/com/bbflight/background_downloader/TaskWorker.kt
@@ -495,11 +495,11 @@ class TaskWorker(
                 else -> {
                     Log.w(
                             TAG,
-                            "Error for url ${task.url} and $filePath: ${e.message} $e ${e.localizedMessage}"
+                            "Error for url ${task.url} and $filePath: ${e.message}"
                     )
                     e.printStackTrace()
                     taskError = TaskError(ErrorType.general, description =
-                    "Error for url ${task.url} and $filePath: ${e.message} $e ${e.localizedMessage}")
+                    "Error for url ${task.url} and $filePath: ${e.message}")
                 }
             }
         }

--- a/android/src/main/kotlin/com/bbflight/background_downloader/TaskWorker.kt
+++ b/android/src/main/kotlin/com/bbflight/background_downloader/TaskWorker.kt
@@ -469,14 +469,12 @@ class TaskWorker(
     ): TaskStatus {
         val filePath = task.filePath(applicationContext)
         try {
+            connection.requestMethod = task.httpRequestMethod
             if (task.isDownloadTask()) {
                 if (task.post != null) {
-                    connection.requestMethod = "POST"
                     connection.doOutput = true
                     connection.setFixedLengthStreamingMode(task.post.length)
                     DataOutputStream(connection.outputStream).use { it.writeBytes(task.post) }
-                } else {
-                    connection.requestMethod = "GET"
                 }
                 return processDownload(
                     connection, task, filePath, isResume, tempFilePath
@@ -679,7 +677,6 @@ class TaskWorker(
     private suspend fun processUpload(
         connection: HttpURLConnection, task: Task, filePath: String
     ): TaskStatus {
-        connection.requestMethod = "POST"
         connection.doOutput = true
         val file = File(filePath)
         if (!file.exists() || !file.isFile) {

--- a/android/src/main/kotlin/com/bbflight/background_downloader/TaskWorker.kt
+++ b/android/src/main/kotlin/com/bbflight/background_downloader/TaskWorker.kt
@@ -140,7 +140,10 @@ class TaskWorker(
          * Optional [taskException] for status .failed
          * */
         suspend fun processStatusUpdate(
-            task: Task, status: TaskStatus, prefs: SharedPreferences, taskException: TaskException? =
+            task: Task,
+            status: TaskStatus,
+            prefs: SharedPreferences,
+            taskException: TaskException? =
                 null
         ) {
             val retryNeeded = status == TaskStatus.failed && task.retriesRemaining > 0
@@ -608,7 +611,8 @@ class TaskWorker(
                     // so if allowed, pause it and schedule the resume task immediately
                     if (!task.allowPause) {
                         Log.i(TAG, "Task ${task.taskId} timed out")
-                        taskException = TaskException(ExceptionType.connection, description = "Task timed out")
+                        taskException =
+                            TaskException(ExceptionType.connection, description = "Task timed out")
                         return TaskStatus.failed
                     }
                     if (taskCanResume) {
@@ -628,7 +632,8 @@ class TaskWorker(
                         return TaskStatus.paused
                     }
                     Log.i(TAG, "Task ${task.taskId} timed out and cannot pause/resume")
-                    taskException = TaskException(ExceptionType.connection, description = "Task timed out")
+                    taskException =
+                        TaskException(ExceptionType.connection, description = "Task timed out")
                     deleteTempFile(tempFilePath)
                     return TaskStatus.failed
                 }

--- a/example/integration_test/downloader_integration_test.dart
+++ b/example/integration_test/downloader_integration_test.dart
@@ -924,6 +924,15 @@ void main() {
       expect(progressCallbackCounter, greaterThanOrEqualTo(10));
     });
 
+    testWidgets('batch download with onElapsedTime', (widgetTester) async {
+      final tasks = <DownloadTask>[DownloadTask(url: urlWithContentLength), DownloadTask(url: urlWithContentLength), DownloadTask(url: urlWithContentLength)];
+      var ticks = 0;
+      final result = await FileDownloader().downloadBatch(tasks, onElapsedTime: (elapsed) => ticks++, elapsedTimeInterval: const Duration(milliseconds: 200));
+      expect(result.numSucceeded, equals(3));
+      expect(ticks, greaterThan(0));
+      await Future.delayed(const Duration(seconds: 10));
+    });
+
     testWidgets('convenience download with callbacks', (widgetTester) async {
       var result = await FileDownloader().download(task,
           onStatus: (status) => statusCallback(TaskStatusUpdate(task, status)));
@@ -1006,6 +1015,19 @@ void main() {
           .then((value) => expect(value.status, equals(TaskStatus.failed)));
       expect(statusCallbackCounter, equals(12));
       print('Finished simple parallel convenience downloads with callbacks');
+    });
+
+    testWidgets('onElapsedTime', (widgetTester) async {
+      task = DownloadTask(url: urlWithContentLength);
+      var ticks = 0;
+      final result = await FileDownloader().download(task,
+          onElapsedTime: (elapsed) {
+            print('Elapsed time: $elapsed');
+            ticks++;
+          },
+          elapsedTimeInterval: const Duration(milliseconds: 200));
+      expect(result.status, equals(TaskStatus.complete));
+      expect(ticks, greaterThan(0));
     });
   });
 
@@ -1509,6 +1531,15 @@ void main() {
       print('Finished batch upload with callback');
     });
 
+    testWidgets('batch upload with onElapsedTime', (widgetTester) async {
+      final tasks = <UploadTask>[uploadTask, uploadTask.copyWith(taskId: 'task2'), uploadTask.copyWith(taskId: 'task3')];
+      var ticks = 0;
+      final result = await FileDownloader().uploadBatch(tasks, onElapsedTime: (elapsed) => ticks++, elapsedTimeInterval: const Duration(milliseconds: 200));
+      expect(result.numSucceeded, equals(3));
+      expect(ticks, greaterThan(0));
+      await Future.delayed(const Duration(seconds: 10));
+    });
+
     testWidgets('convenience upload with callbacks', (widgetTester) async {
       var result = await FileDownloader().upload(uploadTask,
           onStatus: (status) =>
@@ -1532,6 +1563,18 @@ void main() {
       expect(progressCallbackCounter, greaterThan(1));
       expect(lastProgress, equals(1.0));
       print('Finished convenience upload with callbacks');
+    });
+
+    testWidgets('onElapsedTime', (widgetTester) async {
+      var ticks = 0;
+      final result = await FileDownloader().upload(uploadTask,
+          onElapsedTime: (elapsed) {
+            print('Elapsed time: $elapsed');
+            ticks++;
+          },
+          elapsedTimeInterval: const Duration(milliseconds: 200));
+      expect(result.status, equals(TaskStatus.complete));
+      expect(ticks, greaterThan(0));
     });
   });
 

--- a/example/integration_test/downloader_integration_test.dart
+++ b/example/integration_test/downloader_integration_test.dart
@@ -925,9 +925,15 @@ void main() {
     });
 
     testWidgets('batch download with onElapsedTime', (widgetTester) async {
-      final tasks = <DownloadTask>[DownloadTask(url: urlWithContentLength), DownloadTask(url: urlWithContentLength), DownloadTask(url: urlWithContentLength)];
+      final tasks = <DownloadTask>[
+        DownloadTask(url: urlWithContentLength),
+        DownloadTask(url: urlWithContentLength),
+        DownloadTask(url: urlWithContentLength)
+      ];
       var ticks = 0;
-      final result = await FileDownloader().downloadBatch(tasks, onElapsedTime: (elapsed) => ticks++, elapsedTimeInterval: const Duration(milliseconds: 200));
+      final result = await FileDownloader().downloadBatch(tasks,
+          onElapsedTime: (elapsed) => ticks++,
+          elapsedTimeInterval: const Duration(milliseconds: 200));
       expect(result.numSucceeded, equals(3));
       expect(ticks, greaterThan(0));
       await Future.delayed(const Duration(seconds: 10));
@@ -1020,12 +1026,11 @@ void main() {
     testWidgets('onElapsedTime', (widgetTester) async {
       task = DownloadTask(url: urlWithContentLength);
       var ticks = 0;
-      final result = await FileDownloader().download(task,
-          onElapsedTime: (elapsed) {
-            print('Elapsed time: $elapsed');
-            ticks++;
-          },
-          elapsedTimeInterval: const Duration(milliseconds: 200));
+      final result =
+          await FileDownloader().download(task, onElapsedTime: (elapsed) {
+        print('Elapsed time: $elapsed');
+        ticks++;
+      }, elapsedTimeInterval: const Duration(milliseconds: 200));
       expect(result.status, equals(TaskStatus.complete));
       expect(ticks, greaterThan(0));
     });
@@ -1532,9 +1537,15 @@ void main() {
     });
 
     testWidgets('batch upload with onElapsedTime', (widgetTester) async {
-      final tasks = <UploadTask>[uploadTask, uploadTask.copyWith(taskId: 'task2'), uploadTask.copyWith(taskId: 'task3')];
+      final tasks = <UploadTask>[
+        uploadTask,
+        uploadTask.copyWith(taskId: 'task2'),
+        uploadTask.copyWith(taskId: 'task3')
+      ];
       var ticks = 0;
-      final result = await FileDownloader().uploadBatch(tasks, onElapsedTime: (elapsed) => ticks++, elapsedTimeInterval: const Duration(milliseconds: 200));
+      final result = await FileDownloader().uploadBatch(tasks,
+          onElapsedTime: (elapsed) => ticks++,
+          elapsedTimeInterval: const Duration(milliseconds: 200));
       expect(result.numSucceeded, equals(3));
       expect(ticks, greaterThan(0));
       await Future.delayed(const Duration(seconds: 10));
@@ -1567,12 +1578,11 @@ void main() {
 
     testWidgets('onElapsedTime', (widgetTester) async {
       var ticks = 0;
-      final result = await FileDownloader().upload(uploadTask,
-          onElapsedTime: (elapsed) {
-            print('Elapsed time: $elapsed');
-            ticks++;
-          },
-          elapsedTimeInterval: const Duration(milliseconds: 200));
+      final result =
+          await FileDownloader().upload(uploadTask, onElapsedTime: (elapsed) {
+        print('Elapsed time: $elapsed');
+        ticks++;
+      }, elapsedTimeInterval: const Duration(milliseconds: 200));
       expect(result.status, equals(TaskStatus.complete));
       expect(ticks, greaterThan(0));
     });
@@ -1659,7 +1669,7 @@ void main() {
       final record = await FileDownloader().database.recordForId(task.taskId);
       expect(record, isNotNull);
       expect(record?.taskId, equals(task.taskId));
-      expect(record?.taskStatus, equals(TaskStatus.running));
+      expect(record?.status, equals(TaskStatus.running));
       expect(record?.progress, greaterThan(0));
       expect(record?.progress, equals(lastProgress));
       expect(record?.exception, isNull);
@@ -1668,7 +1678,7 @@ void main() {
       final record2 = await FileDownloader().database.recordForId(task.taskId);
       expect(record2, isNotNull);
       expect(record2?.taskId, equals(task.taskId));
-      expect(record2?.taskStatus, equals(TaskStatus.complete));
+      expect(record2?.status, equals(TaskStatus.complete));
       expect(record2?.progress, equals(progressComplete));
       expect(record2?.exception, isNull);
       final records = await FileDownloader().database.allRecords();
@@ -1709,7 +1719,7 @@ void main() {
       record = await FileDownloader().database.recordForId(task.taskId);
       expect(record, isNotNull);
       expect(record?.taskId, equals(task.taskId));
-      expect(record?.taskStatus, equals(TaskStatus.running));
+      expect(record?.status, equals(TaskStatus.running));
       expect(record?.progress, greaterThan(0));
       expect(record?.progress, equals(lastProgress));
       expect(record?.exception, isNull);
@@ -1757,7 +1767,7 @@ void main() {
       final records = await FileDownloader().database.allRecords();
       expect(records.length, equals(1));
       expect(records.first.taskId, equals(task.taskId));
-      expect(records.first.taskStatus, equals(TaskStatus.complete));
+      expect(records.first.status, equals(TaskStatus.complete));
       expect(records.first.progress, equals(progressComplete));
     });
 
@@ -1782,13 +1792,13 @@ void main() {
       await FileDownloader().cancelTasksWithIds([task.taskId]);
       await Future.delayed(const Duration(milliseconds: 500));
       final record = await FileDownloader().database.recordForId(task.taskId);
-      expect(record?.taskStatus, equals(TaskStatus.canceled));
+      expect(record?.status, equals(TaskStatus.canceled));
       expect(File(filePath).existsSync(), isFalse);
       // reactivate tracking, this time with markDownloadedComplete = true
       await FileDownloader().trackTasks();
       // because no file, status does not change
       final record2 = await FileDownloader().database.recordForId(task.taskId);
-      expect(record2?.taskStatus, equals(TaskStatus.canceled));
+      expect(record2?.status, equals(TaskStatus.canceled));
       expect(record2?.progress, equals(record?.progress));
       // create a 'downloaded' file (even though the task was canceled)
       await File(filePath).writeAsString('test');
@@ -1796,7 +1806,7 @@ void main() {
       await FileDownloader().trackTasks();
       // status and progress should now reflect 'complete'
       final record3 = await FileDownloader().database.recordForId(task.taskId);
-      expect(record3?.taskStatus, equals(TaskStatus.complete));
+      expect(record3?.status, equals(TaskStatus.complete));
       expect(record3?.progress, equals(progressComplete));
       print('Finished markDownloadedComplete');
     });
@@ -1819,7 +1829,7 @@ void main() {
       final record = await FileDownloader().database.recordForId(task.taskId);
       expect(record, isNotNull);
       expect(record?.taskId, equals(task.taskId));
-      expect(record?.taskStatus, equals(TaskStatus.failed));
+      expect(record?.status, equals(TaskStatus.failed));
       expect(record?.progress, equals(progressFailed));
       expect(record?.exception, isNotNull);
       final exception = (record?.exception)!;
@@ -2042,8 +2052,8 @@ void main() {
     // passing tests in this group is not sufficient evidence that they
     // are working properly
     testWidgets('NotificationConfig', (widgetTester) async {
-      FileDownloader()
-          .configureNotification(running: TaskNotification('Title', 'Body'));
+      FileDownloader().configureNotification(
+          running: const TaskNotification('Title', 'Body'));
       FileDownloader().registerCallbacks(
           taskStatusCallback: statusCallback,
           taskProgressCallback: progressCallback);

--- a/example/integration_test/downloader_integration_test.dart
+++ b/example/integration_test/downloader_integration_test.dart
@@ -152,7 +152,8 @@ void main() {
     });
 
     test('task with httpRequestMethod', () {
-      expect(() => DownloadTask(url: workingUrl, httpRequestMethod: 'ILLEGAL'), throwsArgumentError);
+      expect(() => DownloadTask(url: workingUrl, httpRequestMethod: 'ILLEGAL'),
+          throwsArgumentError);
     });
   });
 
@@ -197,9 +198,8 @@ void main() {
           filename: defaultFilename);
       path =
           join((await getApplicationDocumentsDirectory()).path, task.filename);
-      expect(
-          (await FileDownloader().download(task)).status, equals(TaskStatus
-          .complete));
+      expect((await FileDownloader().download(task)).status,
+          equals(TaskStatus.complete));
       var result = jsonDecode(await File(path).readAsString());
       expect(result['args']['json'], equals('true'));
       expect(result['args']['test'], equals('with space'));
@@ -213,9 +213,8 @@ void main() {
           filename: defaultFilename);
       path =
           join((await getApplicationDocumentsDirectory()).path, task.filename);
-      expect(
-          (await FileDownloader().download(task)).status, equals(TaskStatus
-          .complete));
+      expect((await FileDownloader().download(task)).status,
+          equals(TaskStatus.complete));
       result = jsonDecode(await File(path).readAsString());
       expect(result['isPatch'], isTrue);
       await File(path).delete();
@@ -309,7 +308,8 @@ void main() {
             expect(update.exception, isNotNull);
             expect(update.exception is TaskHttpException, isTrue);
             expect(update.exception?.description, equals('Not authorized'));
-            expect((update.exception as TaskHttpException).httpResponseCode, equals(403));
+            expect((update.exception as TaskHttpException).httpResponseCode,
+                equals(403));
           }
           statusCallback(update);
         }
@@ -925,8 +925,8 @@ void main() {
     });
 
     testWidgets('convenience download with callbacks', (widgetTester) async {
-      var result = await FileDownloader()
-          .download(task, onStatus: (status) => statusCallback(TaskStatusUpdate(task, status)));
+      var result = await FileDownloader().download(task,
+          onStatus: (status) => statusCallback(TaskStatusUpdate(task, status)));
       expect(result.task, equals(task));
       expect(result.status, equals(TaskStatus.complete));
       expect(statusCallbackCounter, equals(3));
@@ -940,7 +940,8 @@ void main() {
       task = DownloadTask(url: urlWithContentLength, filename: defaultFilename);
       result = await FileDownloader().download(task,
           onStatus: (status) => statusCallback(TaskStatusUpdate(task, status)),
-          onProgress: (progress) => progressCallback(TaskProgressUpdate(task, progress)));
+          onProgress: (progress) =>
+              progressCallback(TaskProgressUpdate(task, progress)));
       expect(result.status, equals(TaskStatus.complete));
       expect(statusCallbackCounter, equals(3));
       expect(progressCallbackCounter, greaterThan(1));
@@ -980,10 +981,12 @@ void main() {
         expect(p2, closeTo(1.0, 0.1)); // complete [1]
         expect(p3, closeTo(1.0, 0.1)); // complete [1]
       }
-      successResult.then((value) => expect(value.status, equals(TaskStatus.complete)));
+      successResult
+          .then((value) => expect(value.status, equals(TaskStatus.complete)));
       successResult2
           .then((value) => expect(value.status, equals(TaskStatus.complete)));
-      failingResult.then((value) => expect(value.status, equals(TaskStatus.failed)));
+      failingResult
+          .then((value) => expect(value.status, equals(TaskStatus.failed)));
       print('Finished parallel convenience downloads with callbacks');
     });
 
@@ -992,12 +995,15 @@ void main() {
       final failTask =
           DownloadTask(url: failingUrl, filename: defaultFilename, retries: 2);
       var failingResult = FileDownloader().download(failTask,
-          onStatus: (status) => statusCallback(TaskStatusUpdate(failTask, status)));
-      var successResult = FileDownloader()
-          .download(task, onStatus: (status) => statusCallback(TaskStatusUpdate(task, status)));
+          onStatus: (status) =>
+              statusCallback(TaskStatusUpdate(failTask, status)));
+      var successResult = FileDownloader().download(task,
+          onStatus: (status) => statusCallback(TaskStatusUpdate(task, status)));
       await Future.wait([successResult, failingResult]);
-      successResult.then((value) => expect(value.status, equals(TaskStatus.complete)));
-      failingResult.then((value) => expect(value.status, equals(TaskStatus.failed)));
+      successResult
+          .then((value) => expect(value.status, equals(TaskStatus.complete)));
+      failingResult
+          .then((value) => expect(value.status, equals(TaskStatus.failed)));
       expect(statusCallbackCounter, equals(12));
       print('Finished simple parallel convenience downloads with callbacks');
     });
@@ -1145,9 +1151,8 @@ void main() {
           post: '');
       final path =
           join((await getApplicationDocumentsDirectory()).path, task.filename);
-      expect(
-          (await FileDownloader().download(task)).status, equals(TaskStatus
-          .complete));
+      expect((await FileDownloader().download(task)).status,
+          equals(TaskStatus.complete));
       final result = jsonDecode(await File(path).readAsString());
       print(result);
       expect(result['args']['request-type'], equals('post-empty'));
@@ -1165,9 +1170,8 @@ void main() {
           post: 'testPost');
       final path =
           join((await getApplicationDocumentsDirectory()).path, task.filename);
-      expect(
-          (await FileDownloader().download(task)).status, equals(TaskStatus
-          .complete));
+      expect((await FileDownloader().download(task)).status,
+          equals(TaskStatus.complete));
       final result = jsonDecode(await File(path).readAsString());
       print(result);
       expect(result['args']['request-type'], equals('post-String'));
@@ -1187,9 +1191,8 @@ void main() {
           post: Uint8List.fromList('testPost'.codeUnits));
       final path =
           join((await getApplicationDocumentsDirectory()).path, task.filename);
-      expect(
-          (await FileDownloader().download(task)).status, equals(TaskStatus
-          .complete));
+      expect((await FileDownloader().download(task)).status,
+          equals(TaskStatus.complete));
       final result = jsonDecode(await File(path).readAsString());
       print(result);
       expect(result['args']['request-type'], equals('post-Uint8List'));
@@ -1213,9 +1216,8 @@ void main() {
           post: '{"field1": 1}');
       final path =
           join((await getApplicationDocumentsDirectory()).path, task.filename);
-      expect(
-          (await FileDownloader().download(task)).status, equals(TaskStatus
-          .complete));
+      expect((await FileDownloader().download(task)).status,
+          equals(TaskStatus.complete));
       final result = jsonDecode(await File(path).readAsString());
       print(result);
       expect(result['args']['request-type'], equals('post-json'));
@@ -1509,7 +1511,8 @@ void main() {
 
     testWidgets('convenience upload with callbacks', (widgetTester) async {
       var result = await FileDownloader().upload(uploadTask,
-          onStatus: (status) => statusCallback(TaskStatusUpdate(uploadTask, status)));
+          onStatus: (status) =>
+              statusCallback(TaskStatusUpdate(uploadTask, status)));
       expect(result.status, equals(TaskStatus.complete));
       expect(statusCallbackCounter, equals(3));
       expect(progressCallbackCompleter.isCompleted, isFalse);
@@ -1522,7 +1525,8 @@ void main() {
       final task2 = uploadTask.copyWith(taskId: 'second');
       result = await FileDownloader().upload(task2,
           onStatus: (status) => statusCallback(TaskStatusUpdate(task2, status)),
-          onProgress: (progress) => progressCallback(TaskProgressUpdate(task2, progress)));
+          onProgress: (progress) =>
+              progressCallback(TaskProgressUpdate(task2, progress)));
       expect(result.status, equals(TaskStatus.complete));
       expect(statusCallbackCounter, equals(3));
       expect(progressCallbackCounter, greaterThan(1));
@@ -1627,6 +1631,46 @@ void main() {
       final records = await FileDownloader().database.allRecords();
       expect(records.length, equals(1));
       expect(records.first, equals(record2));
+    });
+
+    testWidgets('activate tracking for group', (widgetTester) async {
+      await FileDownloader().database.deleteAllRecords();
+      await FileDownloader()
+          .registerCallbacks(
+              group: 'testGroup',
+              taskStatusCallback: statusCallback,
+              taskProgressCallback: progressCallback)
+          .trackTasksInGroup('someGroup', markDownloadedComplete: false);
+      task = DownloadTask(
+          url: urlWithContentLength,
+          filename: defaultFilename,
+          group: 'testGroup',
+          updates: Updates.statusAndProgress);
+      expect(await FileDownloader().enqueue(task), equals(true));
+      await someProgressCompleter.future;
+      // after some progress, expect nothing in database
+      var record = await FileDownloader().database.recordForId(task.taskId);
+      expect(record, isNull);
+      await statusCallbackCompleter.future;
+      await FileDownloader().trackTasks(); // now track all tasks
+      statusCallbackCompleter = Completer();
+      someProgressCompleter = Completer();
+      task = DownloadTask(
+          url: urlWithContentLength,
+          filename: defaultFilename,
+          group: 'testGroup',
+          updates: Updates.statusAndProgress);
+      expect(await FileDownloader().enqueue(task), equals(true));
+      await someProgressCompleter.future;
+      // now expect progress and status in the database
+      record = await FileDownloader().database.recordForId(task.taskId);
+      expect(record, isNotNull);
+      expect(record?.taskId, equals(task.taskId));
+      expect(record?.taskStatus, equals(TaskStatus.running));
+      expect(record?.progress, greaterThan(0));
+      expect(record?.progress, equals(lastProgress));
+      expect(record?.exception, isNull);
+      await statusCallbackCompleter.future;
     });
 
     testWidgets('set, get and delete record', (widgetTester) async {
@@ -1883,7 +1927,8 @@ void main() {
       // kick off convenience download but do not wait for the result
       unawaited(FileDownloader().download(task,
           onStatus: (status) => statusCallback(TaskStatusUpdate(task, status)),
-          onProgress: (progress) => progressCallback(TaskProgressUpdate(task, progress))));
+          onProgress: (progress) =>
+              progressCallback(TaskProgressUpdate(task, progress))));
       await someProgressCompleter.future;
       expect(await FileDownloader().pause(task), equals(true));
       await Future.delayed(const Duration(milliseconds: 250));
@@ -2113,8 +2158,7 @@ void main() {
 
   group('Exception details', () {
     testWidgets('httpResponse: 403 downloadTask', (widgetTester) async {
-      FileDownloader().registerCallbacks(
-          taskStatusCallback: statusCallback);
+      FileDownloader().registerCallbacks(taskStatusCallback: statusCallback);
       task = DownloadTask(url: failingUrl, filename: 'test');
       expect(await FileDownloader().enqueue(task), isTrue);
       await statusCallbackCompleter.future;
@@ -2127,14 +2171,14 @@ void main() {
     testWidgets('fileSystem: File to upload does not exist',
         (widgetTester) async {
       if (!Platform.isIOS) {
-        FileDownloader().registerCallbacks(
-            taskStatusCallback: statusCallback);
+        FileDownloader().registerCallbacks(taskStatusCallback: statusCallback);
         uploadTask = uploadTask.copyWith(filename: 'doesNotExist');
         expect(await FileDownloader().enqueue(uploadTask), isTrue);
         await statusCallbackCompleter.future;
         final exception = lastException!;
         expect(exception is TaskFileSystemException, isTrue);
-        expect(exception.description.startsWith('File to upload does not exist'),
+        expect(
+            exception.description.startsWith('File to upload does not exist'),
             isTrue);
       }
     });

--- a/example/integration_test/downloader_integration_test.dart
+++ b/example/integration_test/downloader_integration_test.dart
@@ -1905,6 +1905,12 @@ void main() {
       }
     });
   });
+
+  group('Error details', () {
+    testWidgets('register callback with error', (widgetTester) async {
+
+    });
+  });
 }
 
 /// Helper: make sure [task] is set as desired, and this will enqueue, wait for

--- a/example/integration_test/downloader_integration_test.dart
+++ b/example/integration_test/downloader_integration_test.dart
@@ -58,6 +58,9 @@ void statusCallback(TaskStatusUpdate update) {
   final task = update.task;
   final status = update.status;
   print('statusCallback for $task with status $status');
+  if (update.exception != null) {
+    print('Exception: ${update.exception}');
+  }
   lastStatus = status;
   lastException = update.exception;
   statusCallbackCounter++;
@@ -195,7 +198,8 @@ void main() {
       path =
           join((await getApplicationDocumentsDirectory()).path, task.filename);
       expect(
-          await FileDownloader().download(task), equals(TaskStatus.complete));
+          (await FileDownloader().download(task)).status, equals(TaskStatus
+          .complete));
       var result = jsonDecode(await File(path).readAsString());
       expect(result['args']['json'], equals('true'));
       expect(result['args']['test'], equals('with space'));
@@ -210,7 +214,8 @@ void main() {
       path =
           join((await getApplicationDocumentsDirectory()).path, task.filename);
       expect(
-          await FileDownloader().download(task), equals(TaskStatus.complete));
+          (await FileDownloader().download(task)).status, equals(TaskStatus
+          .complete));
       result = jsonDecode(await File(path).readAsString());
       expect(result['isPatch'], isTrue);
       await File(path).delete();
@@ -541,7 +546,7 @@ void main() {
           url: postTestUrl,
           filename: defaultFilename,
           headers: {'Auth': 'Test'},
-          httpRequestMethod: 'GET',
+          httpRequestMethod: 'post',
           post: 'TestPost',
           directory: 'directory',
           baseDirectory: BaseDirectory.temporary,
@@ -594,7 +599,7 @@ void main() {
           url: uploadTestUrl,
           filename: uploadFilename,
           headers: {'Auth': 'Test'},
-          httpRequestMethod: 'POST',
+          httpRequestMethod: 'post',
           post: null,
           fileField: 'fileField',
           mimeType: 'text/html',
@@ -606,6 +611,7 @@ void main() {
           allowPause: false,
           // cannot be true if post != null
           metaData: 'someMetaData');
+      expect(complexTask.httpRequestMethod, equals('POST'));
       final now = DateTime.now();
       expect(now.difference(complexTask.creationTime).inMilliseconds,
           lessThan(100));
@@ -1140,7 +1146,8 @@ void main() {
       final path =
           join((await getApplicationDocumentsDirectory()).path, task.filename);
       expect(
-          await FileDownloader().download(task), equals(TaskStatus.complete));
+          (await FileDownloader().download(task)).status, equals(TaskStatus
+          .complete));
       final result = jsonDecode(await File(path).readAsString());
       print(result);
       expect(result['args']['request-type'], equals('post-empty'));
@@ -1159,7 +1166,8 @@ void main() {
       final path =
           join((await getApplicationDocumentsDirectory()).path, task.filename);
       expect(
-          await FileDownloader().download(task), equals(TaskStatus.complete));
+          (await FileDownloader().download(task)).status, equals(TaskStatus
+          .complete));
       final result = jsonDecode(await File(path).readAsString());
       print(result);
       expect(result['args']['request-type'], equals('post-String'));
@@ -1180,7 +1188,8 @@ void main() {
       final path =
           join((await getApplicationDocumentsDirectory()).path, task.filename);
       expect(
-          await FileDownloader().download(task), equals(TaskStatus.complete));
+          (await FileDownloader().download(task)).status, equals(TaskStatus
+          .complete));
       final result = jsonDecode(await File(path).readAsString());
       print(result);
       expect(result['args']['request-type'], equals('post-Uint8List'));
@@ -1205,7 +1214,8 @@ void main() {
       final path =
           join((await getApplicationDocumentsDirectory()).path, task.filename);
       expect(
-          await FileDownloader().download(task), equals(TaskStatus.complete));
+          (await FileDownloader().download(task)).status, equals(TaskStatus
+          .complete));
       final result = jsonDecode(await File(path).readAsString());
       print(result);
       expect(result['args']['request-type'], equals('post-json'));
@@ -1960,7 +1970,7 @@ void main() {
 
     testWidgets('openFile', (widgetTester) async {
       final result = await FileDownloader().download(task);
-      expect(result, equals(TaskStatus.complete));
+      expect(result.status, equals(TaskStatus.complete));
       var success = await FileDownloader().openFile(task: task);
       if (!Platform.isAndroid) {
         expect(success, isTrue);
@@ -2102,7 +2112,7 @@ void main() {
   });
 
   group('Exception details', () {
-    testWidgets('httpResponse: 403', (widgetTester) async {
+    testWidgets('httpResponse: 403 downloadTask', (widgetTester) async {
       FileDownloader().registerCallbacks(
           taskStatusCallback: statusCallback);
       task = DownloadTask(url: failingUrl, filename: 'test');

--- a/example/integration_test/downloader_integration_test.dart
+++ b/example/integration_test/downloader_integration_test.dart
@@ -384,6 +384,19 @@ void main() {
         }
       }
     });
+
+    testWidgets('enqueue with invalid (malformed) url', (widgetTester) async {
+      var task = DownloadTask(url: 'invalid%url.com', filename: 'test.html');
+      expect(await FileDownloader().enqueue(task), isFalse);
+      task = DownloadTask(
+          url: 'http://google.com?query=5&some%other=true',
+          filename: 'test.html');
+      expect(await FileDownloader().enqueue(task), isFalse);
+      task = DownloadTask(
+          url: 'http://google.com?query=5&some%20other=true',
+          filename: 'test.html');
+      expect(await FileDownloader().enqueue(task), isTrue);
+    });
   });
 
   group('Queue and task management', () {

--- a/example/integration_test/downloader_integration_test.dart
+++ b/example/integration_test/downloader_integration_test.dart
@@ -777,8 +777,8 @@ void main() {
       if (exists) {
         await File(path).delete();
       }
-      final status = await FileDownloader().download(task);
-      expect(status, equals(TaskStatus.complete));
+      final result = await FileDownloader().download(task);
+      expect(result.status, equals(TaskStatus.complete));
       exists = await File(path).exists();
       expect(exists, isTrue);
       await File(path).delete();
@@ -804,9 +804,9 @@ void main() {
       // var result = await FileDownloader().download(task);
       final taskFuture = FileDownloader().download(task);
       final secondTaskFuture = FileDownloader().download(secondTask);
-      var statuses = await Future.wait([taskFuture, secondTaskFuture]);
-      for (var status in statuses) {
-        expect(status, equals(TaskStatus.complete));
+      var results = await Future.wait([taskFuture, secondTaskFuture]);
+      for (var result in results) {
+        expect(result.status, equals(TaskStatus.complete));
       }
       exists = await File(path).exists();
       expect(exists, isTrue);
@@ -921,7 +921,8 @@ void main() {
     testWidgets('convenience download with callbacks', (widgetTester) async {
       var result = await FileDownloader()
           .download(task, onStatus: (status) => statusCallback(TaskStatusUpdate(task, status)));
-      expect(result, equals(TaskStatus.complete));
+      expect(result.task, equals(task));
+      expect(result.status, equals(TaskStatus.complete));
       expect(statusCallbackCounter, equals(3));
       expect(progressCallbackCompleter.isCompleted, isFalse);
       expect(progressCallbackCounter, equals(0));
@@ -934,7 +935,7 @@ void main() {
       result = await FileDownloader().download(task,
           onStatus: (status) => statusCallback(TaskStatusUpdate(task, status)),
           onProgress: (progress) => progressCallback(TaskProgressUpdate(task, progress)));
-      expect(result, equals(TaskStatus.complete));
+      expect(result.status, equals(TaskStatus.complete));
       expect(statusCallbackCounter, equals(3));
       expect(progressCallbackCounter, greaterThan(1));
       expect(lastProgress, equals(1.0));
@@ -973,10 +974,10 @@ void main() {
         expect(p2, closeTo(1.0, 0.1)); // complete [1]
         expect(p3, closeTo(1.0, 0.1)); // complete [1]
       }
-      successResult.then((value) => expect(value, equals(TaskStatus.complete)));
+      successResult.then((value) => expect(value.status, equals(TaskStatus.complete)));
       successResult2
-          .then((value) => expect(value, equals(TaskStatus.complete)));
-      failingResult.then((value) => expect(value, equals(TaskStatus.failed)));
+          .then((value) => expect(value.status, equals(TaskStatus.complete)));
+      failingResult.then((value) => expect(value.status, equals(TaskStatus.failed)));
       print('Finished parallel convenience downloads with callbacks');
     });
 
@@ -989,8 +990,8 @@ void main() {
       var successResult = FileDownloader()
           .download(task, onStatus: (status) => statusCallback(TaskStatusUpdate(task, status)));
       await Future.wait([successResult, failingResult]);
-      successResult.then((value) => expect(value, equals(TaskStatus.complete)));
-      failingResult.then((value) => expect(value, equals(TaskStatus.failed)));
+      successResult.then((value) => expect(value.status, equals(TaskStatus.complete)));
+      failingResult.then((value) => expect(value.status, equals(TaskStatus.failed)));
       expect(statusCallbackCounter, equals(12));
       print('Finished simple parallel convenience downloads with callbacks');
     });
@@ -1428,8 +1429,8 @@ void main() {
 
   group('Convenience uploads', () {
     testWidgets('upload with await', (widgetTester) async {
-      final status = await FileDownloader().upload(uploadTask);
-      expect(status, equals(TaskStatus.complete));
+      final result = await FileDownloader().upload(uploadTask);
+      expect(result.status, equals(TaskStatus.complete));
     });
 
     testWidgets('multiple upload with futures', (widgetTester) async {
@@ -1439,9 +1440,9 @@ void main() {
       // var result = await FileDownloader().upload(task);
       final taskFuture = FileDownloader().upload(uploadTask);
       final secondTaskFuture = FileDownloader().upload(secondTask);
-      var statuses = await Future.wait([taskFuture, secondTaskFuture]);
-      for (var status in statuses) {
-        expect(status, equals(TaskStatus.complete));
+      var results = await Future.wait([taskFuture, secondTaskFuture]);
+      for (var result in results) {
+        expect(result.status, equals(TaskStatus.complete));
       }
     });
 
@@ -1499,7 +1500,7 @@ void main() {
     testWidgets('convenience upload with callbacks', (widgetTester) async {
       var result = await FileDownloader().upload(uploadTask,
           onStatus: (status) => statusCallback(TaskStatusUpdate(uploadTask, status)));
-      expect(result, equals(TaskStatus.complete));
+      expect(result.status, equals(TaskStatus.complete));
       expect(statusCallbackCounter, equals(3));
       expect(progressCallbackCompleter.isCompleted, isFalse);
       expect(progressCallbackCounter, equals(0));
@@ -1512,7 +1513,7 @@ void main() {
       result = await FileDownloader().upload(task2,
           onStatus: (status) => statusCallback(TaskStatusUpdate(task2, status)),
           onProgress: (progress) => progressCallback(TaskProgressUpdate(task2, progress)));
-      expect(result, equals(TaskStatus.complete));
+      expect(result.status, equals(TaskStatus.complete));
       expect(statusCallbackCounter, equals(3));
       expect(progressCallbackCounter, greaterThan(1));
       expect(lastProgress, equals(1.0));

--- a/example/integration_test/downloader_integration_test.dart
+++ b/example/integration_test/downloader_integration_test.dart
@@ -147,6 +147,10 @@ void main() {
       expect(task.fileField, equals('fileField'));
       expect(task.mimeType, equals('someThing'));
     });
+
+    test('task with httpRequestMethod', () {
+      expect(() => DownloadTask(url: workingUrl, httpRequestMethod: 'ILLEGAL'), throwsArgumentError);
+    });
   });
 
   group('Enqueuing tasks', () {
@@ -192,9 +196,23 @@ void main() {
           join((await getApplicationDocumentsDirectory()).path, task.filename);
       expect(
           await FileDownloader().download(task), equals(TaskStatus.complete));
-      final result = jsonDecode(await File(path).readAsString());
+      var result = jsonDecode(await File(path).readAsString());
       expect(result['args']['json'], equals('true'));
       expect(result['args']['test'], equals('with space'));
+      await File(path).delete();
+
+      // test url with PATCH httpRequestMethod
+      task = DownloadTask(
+          url: getTestUrl,
+          urlQueryParameters: {'json': 'true', 'test': 'with%20space'},
+          httpRequestMethod: 'PATCH',
+          filename: defaultFilename);
+      path =
+          join((await getApplicationDocumentsDirectory()).path, task.filename);
+      expect(
+          await FileDownloader().download(task), equals(TaskStatus.complete));
+      result = jsonDecode(await File(path).readAsString());
+      expect(result['isPatch'], isTrue);
       await File(path).delete();
       print('Finished enqueue');
     });
@@ -523,6 +541,7 @@ void main() {
           url: postTestUrl,
           filename: defaultFilename,
           headers: {'Auth': 'Test'},
+          httpRequestMethod: 'GET',
           post: 'TestPost',
           directory: 'directory',
           baseDirectory: BaseDirectory.temporary,
@@ -547,6 +566,7 @@ void main() {
         expect(task.url, equals(complexTask.url));
         expect(task.filename, equals(complexTask.filename));
         expect(task.headers, equals(complexTask.headers));
+        expect(task.httpRequestMethod, equals(complexTask.httpRequestMethod));
         expect(task.post, equals(complexTask.post));
         expect(task.directory, equals(complexTask.directory));
         expect(task.baseDirectory, equals(complexTask.baseDirectory));
@@ -574,6 +594,7 @@ void main() {
           url: uploadTestUrl,
           filename: uploadFilename,
           headers: {'Auth': 'Test'},
+          httpRequestMethod: 'POST',
           post: null,
           fileField: 'fileField',
           mimeType: 'text/html',
@@ -600,6 +621,7 @@ void main() {
         expect(task.url, equals(complexTask.url));
         expect(task.filename, equals(complexTask.filename));
         expect(task.headers, equals(complexTask.headers));
+        expect(task.httpRequestMethod, equals(complexTask.httpRequestMethod));
         expect(task.post, equals(complexTask.post));
         expect(task.fileField, equals(complexTask.fileField));
         expect(task.mimeType, equals(complexTask.mimeType));
@@ -634,6 +656,7 @@ void main() {
           url: postTestUrl,
           filename: defaultFilename,
           headers: {'Auth': 'Test'},
+          httpRequestMethod: 'PATCH',
           post: 'TestPost',
           directory: 'directory',
           baseDirectory: BaseDirectory.temporary,
@@ -650,6 +673,7 @@ void main() {
       expect(task.url, equals(complexTask.url));
       expect(task.filename, equals(complexTask.filename));
       expect(task.headers, equals(complexTask.headers));
+      expect(task.httpRequestMethod, equals(complexTask.httpRequestMethod));
       expect(task.post, equals(complexTask.post));
       expect(task.directory, equals(complexTask.directory));
       expect(task.baseDirectory, equals(complexTask.baseDirectory));

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -68,9 +68,9 @@ class _MyAppState extends State<MyApp> {
   /// Process the status updates coming from the downloader
   ///
   /// Stores the task status
-  void myDownloadStatusCallback(Task task, TaskStatus status) {
-    if (task == backgroundDownloadTask) {
-      switch (status) {
+  void myDownloadStatusCallback(TaskStatusUpdate update) {
+    if (update.task == backgroundDownloadTask) {
+      switch (update.status) {
         case TaskStatus.enqueued:
         case TaskStatus.notFound:
         case TaskStatus.failed:
@@ -89,7 +89,7 @@ class _MyAppState extends State<MyApp> {
           break;
       }
       setState(() {
-        downloadTaskStatus = status;
+        downloadTaskStatus = update.status;
       });
     }
   }
@@ -97,8 +97,8 @@ class _MyAppState extends State<MyApp> {
   /// Process the progress updates coming from the downloader
   ///
   /// Adds an update object to the stream that the main UI listens to
-  void myDownloadProgressCallback(Task task, double progress) {
-    updateStream.add(DownloadProgressIndicatorUpdate(task.filename, progress));
+  void myDownloadProgressCallback(TaskProgressUpdate update) {
+    updateStream.add(DownloadProgressIndicatorUpdate(update.task.filename, update.progress));
   }
 
   /// Process the user tapping on a notification by printing a message

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -103,7 +103,7 @@ class _MyAppState extends State<MyApp> {
 
   /// Process the user tapping on a notification by printing a message
   void myNotificationTapCallback(Task task, NotificationType notificationType) {
-    print('Tapped notification $notificationType for taskId ${task.taskId}');
+    debugPrint('Tapped notification $notificationType for taskId ${task.taskId}');
   }
 
   @override

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -48,20 +48,21 @@ class _MyAppState extends State<MyApp> {
         .configureNotificationForGroup(FileDownloader.defaultGroup,
             // For the main download button
             // which uses 'enqueue' and a default group
-            running: TaskNotification(
+            running: const TaskNotification(
                 'Download {filename}', 'File: {filename} - {progress}'),
-            complete:
-                TaskNotification('Download {filename}', 'Download complete'),
-            error: TaskNotification('Download {filename}', 'Download failed'),
-            paused: TaskNotification(
+            complete: const TaskNotification(
+                'Download {filename}', 'Download complete'),
+            error: const TaskNotification(
+                'Download {filename}', 'Download failed'),
+            paused: const TaskNotification(
                 'Download {filename}', 'Paused with metadata {metadata}'),
             progressBar: true)
         .configureNotification(
             // for the 'Download & Open' dog picture
             // which uses 'download' which is not the .defaultGroup
             // but the .await group so won't use the above config
-            complete:
-                TaskNotification('Download {filename}', 'Download complete'),
+            complete: const TaskNotification(
+                'Download {filename}', 'Download complete'),
             tapOpensFile: true); // dog can also open directly from tap
   }
 
@@ -98,12 +99,14 @@ class _MyAppState extends State<MyApp> {
   ///
   /// Adds an update object to the stream that the main UI listens to
   void myDownloadProgressCallback(TaskProgressUpdate update) {
-    updateStream.add(DownloadProgressIndicatorUpdate(update.task.filename, update.progress));
+    updateStream.add(
+        DownloadProgressIndicatorUpdate(update.task.filename, update.progress));
   }
 
   /// Process the user tapping on a notification by printing a message
   void myNotificationTapCallback(Task task, NotificationType notificationType) {
-    debugPrint('Tapped notification $notificationType for taskId ${task.taskId}');
+    debugPrint(
+        'Tapped notification $notificationType for taskId ${task.taskId}');
   }
 
   @override

--- a/ios/Classes/Downloader.swift
+++ b/ios/Classes/Downloader.swift
@@ -384,7 +384,7 @@ public class Downloader: NSObject, FlutterPlugin, URLSessionDelegate, URLSession
             Downloader.uploaderForUrlSessionTaskIdentifier.removeValue(forKey: task.taskIdentifier)
         }
         let responseStatusCode = (task.response as! HTTPURLResponse?)?.statusCode ?? 0
-        let responseStatusDescription = (task.response as! HTTPURLResponse?)?.description ?? ""
+        let responseStatusDescription = HTTPURLResponse.localizedString(forStatusCode: responseStatusCode)
         let notificationConfig = getNotificationConfigFrom(urlSessionTask: task)
         guard let task = getTaskFrom(urlSessionTask: task) else {
             os_log("Could not find task related to urlSessionTask %d", log: log, type: .error, task.taskIdentifier)
@@ -511,7 +511,7 @@ public class Downloader: NSObject, FlutterPlugin, URLSessionDelegate, URLSession
         }
         if !(200...206).contains(response.statusCode)   {
             os_log("TaskId %@ returned response code %d", log: log,  type: .info, task.taskId, response.statusCode)
-            processStatusUpdate(task: task, status: TaskStatus.failed, taskError: TaskError(type: .httpResponse, httpResponseCode: response.statusCode, description: response.description))
+            processStatusUpdate(task: task, status: TaskStatus.failed, taskError: TaskError(type: .httpResponse, httpResponseCode: response.statusCode, description: HTTPURLResponse.localizedString(forStatusCode: response.statusCode)))
             updateNotification(task: task, notificationType: .error, notificationConfig: notificationConfig)
             return
         }

--- a/ios/Classes/Downloader.swift
+++ b/ios/Classes/Downloader.swift
@@ -121,7 +121,12 @@ public class Downloader: NSObject, FlutterPlugin, URLSessionDelegate, URLSession
         let verb = isResume ? "Resuming" : "Starting"
         os_log("%@ task with id %@", log: log, type: .info, verb, task.taskId)
         Downloader.urlSession = Downloader.urlSession ?? createUrlSession()
-        var baseRequest = URLRequest(url: URL(string: task.url)!)
+        guard let url = URL(string: task.url) else {
+            os_log("Invalid url: %@", log: log, type: .info, task.url)
+            postResult(result: result, value: false)
+            return
+        }
+        var baseRequest = URLRequest(url: url)
         for (key, value) in task.headers {
             baseRequest.setValue(value, forHTTPHeaderField: key)
         }

--- a/ios/Classes/Task.swift
+++ b/ios/Classes/Task.swift
@@ -61,3 +61,39 @@ enum TaskStatus: Int {
          waitingToRetry,
          paused
 }
+
+enum ErrorType: Int {
+    case
+    // Invalid HTTP response
+    httpResponse,
+
+    // Could not save or find file, or create directory
+    fileSystem,
+
+    // URL incorrect
+    url,
+
+    // Connection problem, eg host not found, timeout
+    connection,
+
+    // Could not resume or pause task
+    resume,
+
+    // General error
+    general
+}
+
+/**
+* Contains error information associated with a failed [Task]
+*
+* The [type] categorizes the error
+* The [httpResponseCode] is only valid if >0 and may offer details about the
+* nature of the error
+* The [description] is typically taken from the platform-generated
+* error message, or from the plugin. The localization is undefined
+*/
+struct TaskError {
+    var type: ErrorType
+    var httpResponseCode: Int
+    var description: String
+}

--- a/ios/Classes/Task.swift
+++ b/ios/Classes/Task.swift
@@ -14,6 +14,7 @@ struct Task : Codable {
     var url: String
     var filename: String
     var headers: [String:String]
+    var httpRequestMethod: String
     var post: String?
     var fileField: String?
     var mimeType: String?
@@ -62,25 +63,28 @@ enum TaskStatus: Int {
          paused
 }
 
-enum ErrorType: Int {
+/// The type of [TaskException]
+enum ExceptionType: String {
     case
-    // Invalid HTTP response
-    httpResponse,
+    
+    // General error
+    general = "TaskException",
+    
 
     // Could not save or find file, or create directory
-    fileSystem,
+    fileSystem = "TaskFileSystemException",
 
     // URL incorrect
-    url,
+    url = "TaskUrlException",
 
     // Connection problem, eg host not found, timeout
-    connection,
+    connection = "TaskConnectionException",
 
     // Could not resume or pause task
-    resume,
+    resume = "TaskResumeException",
 
-    // General error
-    general
+    // Invalid HTTP response
+    httpResponse = "TaskHttpException"
 }
 
 /**
@@ -92,8 +96,8 @@ enum ErrorType: Int {
 * The [description] is typically taken from the platform-generated
 * error message, or from the plugin. The localization is undefined
 */
-struct TaskError {
-    var type: ErrorType
+struct TaskException {
+    var type: ExceptionType
     var httpResponseCode: Int
     var description: String
 }

--- a/ios/Classes/TaskFunctions.swift
+++ b/ios/Classes/TaskFunctions.swift
@@ -60,7 +60,7 @@ func getFilePath(for task: Task) -> String? {
 /// Sends status update via the background channel to Dart, if requested
 /// If the task is finished, processes a final progressUpdate update and removes
 /// task from persistent storage
-func processStatusUpdate(task: Task, status: TaskStatus, taskError: TaskError? = nil) {
+func processStatusUpdate(task: Task, status: TaskStatus, taskException: TaskException? = nil) {
     // Post update if task expects one, or if failed and retry is needed
     let retryNeeded = status == TaskStatus.failed && task.retriesRemaining > 0
     // if task is in final state, process a final progressUpdate
@@ -88,9 +88,9 @@ func processStatusUpdate(task: Task, status: TaskStatus, taskError: TaskError? =
         Downloader.localResumeData.removeValue(forKey: task.taskId)
     }
     if providesStatusUpdates(downloadTask: task) || retryNeeded {
-        let finalTaskError = taskError == nil ? TaskError(type: .general,
-                                                           httpResponseCode: -1, description: "") : taskError
-        let arg: Any = status == .failed ? [status.rawValue, finalTaskError!.type.rawValue, finalTaskError!.httpResponseCode, finalTaskError!.description] : status.rawValue
+        let finalTaskException = taskException == nil ? TaskException(type: .general,
+                                                           httpResponseCode: -1, description: "") : taskException
+        let arg: Any = status == .failed ? [status.rawValue, finalTaskException!.type.rawValue, finalTaskException!.description, finalTaskException!.httpResponseCode] : status.rawValue
         if !postOnBackgroundChannel(method: "statusUpdate", task: task, arg: arg) {
             // store update locally as a merged task/status JSON string, without error info
             guard let jsonData = try? JSONEncoder().encode(task),

--- a/lib/background_downloader.dart
+++ b/lib/background_downloader.dart
@@ -1,3 +1,4 @@
 export 'src/file_downloader.dart' show FileDownloader;
 export 'src/models.dart';
 export 'src/exceptions.dart';
+export 'src/database.dart';

--- a/lib/background_downloader.dart
+++ b/lib/background_downloader.dart
@@ -1,2 +1,3 @@
 export 'src/file_downloader.dart' show FileDownloader;
 export 'src/models.dart';
+export 'src/exceptions.dart';

--- a/lib/src/base_downloader.dart
+++ b/lib/src/base_downloader.dart
@@ -48,7 +48,7 @@ abstract class BaseDownloader {
   var updates = StreamController<TaskUpdate>();
 
   /// Groups tracked in persistent database
-  final trackedGroups = <String>{};
+  final trackedGroups = <String?>{};
 
   /// Map of tasks and completer to indicate whether task can be resumed
   final canResumeTask = <Task, Completer<bool>>{};
@@ -236,7 +236,7 @@ abstract class BaseDownloader {
   /// This is a convenient way to capture downloads that have completed while
   /// the app was suspended, provided you have registered your listeners
   /// or callback before calling this.
-  Future<void> trackTasks(String group, bool markDownloadedComplete) async {
+  Future<void> trackTasks(String? group, bool markDownloadedComplete) async {
     trackedGroups.add(group);
     if (markDownloadedComplete) {
       final records = await Database().allRecords(group: group);
@@ -553,7 +553,7 @@ abstract class BaseDownloader {
   /// Insert or update the [TaskRecord] in the tracking database
   Future<void> _updateTaskInDatabase(Task task,
       {TaskStatus? status, double? progress, TaskException? taskException}) async {
-    if (trackedGroups.contains(task.group)) {
+    if (trackedGroups.contains(null) || trackedGroups.contains(task.group)) {
       if (status == null && progress != null) {
         // update existing record with progress only
         final existingRecord = await Database().recordForId(task.taskId);

--- a/lib/src/base_downloader.dart
+++ b/lib/src/base_downloader.dart
@@ -439,7 +439,8 @@ abstract class BaseDownloader {
   ///
   /// Also manages retries ([tasksWaitingToRetry] and delay) and pause/resume
   /// ([pausedTasks] and [_clearPauseResumeInfo]
-  void processStatusUpdate(Task task, TaskStatus taskStatus, [TaskError? taskError]) {
+  void processStatusUpdate(Task task, TaskStatus taskStatus,
+      [TaskError? taskError]) {
     // Normal status updates are only sent here when the task is expected
     // to provide those.  The exception is a .failed status when a task
     // has retriesRemaining > 0: those are always sent here, and are
@@ -461,8 +462,12 @@ abstract class BaseDownloader {
             log.warning('Could not enqueue task $task after retry timeout');
             removeModifiedTask(task);
             _clearPauseResumeInfo(task);
-            _emitStatusUpdate(task, TaskStatus.failed, TaskError(ErrorType.general,
-            description: 'Could not enqueue task $task after retry timeout'));
+            _emitStatusUpdate(
+                task,
+                TaskStatus.failed,
+                TaskError(ErrorType.general,
+                    description:
+                        'Could not enqueue task $task after retry timeout'));
             _emitProgressUpdate(task, progressFailed);
           }
         }
@@ -508,10 +513,14 @@ abstract class BaseDownloader {
 
   /// Emits the status update for this task to its callback or listener, and
   /// update the task in the database
-  void _emitStatusUpdate(Task task, TaskStatus taskStatus,
-      TaskError? taskError) {
+  void _emitStatusUpdate(
+      Task task, TaskStatus taskStatus, TaskError? taskError) {
     _updateTaskInDatabase(task, status: taskStatus, taskError: taskError);
+    print(taskError);
     if (task.providesStatusUpdates) {
+      if (taskStatus != TaskStatus.failed) {
+        taskError = null;
+      }
       final taskStatusCallback = groupStatusCallbacks[task.group];
       if (taskStatusCallback != null) {
         if (taskStatusCallback is TaskStatusCallback) {
@@ -522,7 +531,7 @@ abstract class BaseDownloader {
         }
       } else {
         if (updates.hasListener) {
-          updates.add(TaskStatusUpdate(task, taskStatus));
+          updates.add(TaskStatusUpdate(task, taskStatus, taskError));
         } else {
           log.warning('Requested status updates for task ${task.taskId} in '
               'group ${task.group} but no TaskStatusCallback '

--- a/lib/src/base_downloader.dart
+++ b/lib/src/base_downloader.dart
@@ -475,7 +475,7 @@ abstract class BaseDownloader {
   /// update the task in the database
   void _emitStatusUpdate(Task task, TaskStatus taskStatus,
       TaskError? taskError) {
-    _updateTaskInDatabase(task, status: taskStatus);
+    _updateTaskInDatabase(task, status: taskStatus, taskError: taskError);
     if (task.providesStatusUpdates) {
       final taskStatusCallback = groupStatusCallbacks[task.group];
       if (taskStatusCallback != null) {
@@ -519,7 +519,7 @@ abstract class BaseDownloader {
 
   /// Insert or update the [TaskRecord] in the tracking database
   Future<void> _updateTaskInDatabase(Task task,
-      {TaskStatus? status, double? progress}) async {
+      {TaskStatus? status, double? progress, TaskError? taskError}) async {
     if (trackedGroups.contains(task.group)) {
       if (status == null && progress != null) {
         // update existing record with progress only
@@ -556,7 +556,7 @@ abstract class BaseDownloader {
             break;
         }
       }
-      Database().updateRecord(TaskRecord(task, status!, progress!));
+      Database().updateRecord(TaskRecord(task, status!, progress!, taskError));
     }
   }
 

--- a/lib/src/base_downloader.dart
+++ b/lib/src/base_downloader.dart
@@ -516,7 +516,6 @@ abstract class BaseDownloader {
   void _emitStatusUpdate(
       Task task, TaskStatus taskStatus, TaskError? taskError) {
     _updateTaskInDatabase(task, status: taskStatus, taskError: taskError);
-    print(taskError);
     if (task.providesStatusUpdates) {
       if (taskStatus != TaskStatus.failed) {
         taskError = null;

--- a/lib/src/base_downloader.dart
+++ b/lib/src/base_downloader.dart
@@ -242,12 +242,13 @@ abstract class BaseDownloader {
       final records = await Database().allRecords(group: group);
       for (var record in records.where((record) =>
           record.task is DownloadTask &&
-          record.taskStatus != TaskStatus.complete)) {
+          record.status != TaskStatus.complete)) {
         final filePath = await record.task.filePath();
         if (await File(filePath).exists()) {
-          processStatusUpdate(TaskStatusUpdate(record.task, TaskStatus.complete));
+          processStatusUpdate(
+              TaskStatusUpdate(record.task, TaskStatus.complete));
           final updatedRecord = record.copyWith(
-              taskStatus: TaskStatus.complete, progress: progressComplete);
+              status: TaskStatus.complete, progress: progressComplete);
           await Database().updateRecord(updatedRecord);
         }
       }
@@ -463,8 +464,11 @@ abstract class BaseDownloader {
             log.warning('Could not enqueue task $task after retry timeout');
             removeModifiedTask(task);
             _clearPauseResumeInfo(task);
-            _emitStatusUpdate(TaskStatusUpdate(task, TaskStatus.failed, TaskException(
-                'Could not enqueue task $task after retry timeout')));
+            _emitStatusUpdate(TaskStatusUpdate(
+                task,
+                TaskStatus.failed,
+                TaskException(
+                    'Could not enqueue task $task after retry timeout')));
             _emitProgressUpdate(TaskProgressUpdate(task, progressFailed));
           }
         }
@@ -512,7 +516,8 @@ abstract class BaseDownloader {
   /// update the task in the database
   void _emitStatusUpdate(TaskStatusUpdate update) {
     final task = update.task;
-    _updateTaskInDatabase(task, status: update.status, taskException: update.exception);
+    _updateTaskInDatabase(task,
+        status: update.status, taskException: update.exception);
     if (task.providesStatusUpdates) {
       final taskStatusCallback = groupStatusCallbacks[task.group];
       if (taskStatusCallback != null) {
@@ -552,7 +557,9 @@ abstract class BaseDownloader {
 
   /// Insert or update the [TaskRecord] in the tracking database
   Future<void> _updateTaskInDatabase(Task task,
-      {TaskStatus? status, double? progress, TaskException? taskException}) async {
+      {TaskStatus? status,
+      double? progress,
+      TaskException? taskException}) async {
     if (trackedGroups.contains(null) || trackedGroups.contains(task.group)) {
       if (status == null && progress != null) {
         // update existing record with progress only
@@ -589,7 +596,8 @@ abstract class BaseDownloader {
             break;
         }
       }
-      Database().updateRecord(TaskRecord(task, status!, progress!, taskException));
+      Database()
+          .updateRecord(TaskRecord(task, status!, progress!, taskException));
     }
   }
 

--- a/lib/src/database.dart
+++ b/lib/src/database.dart
@@ -1,6 +1,7 @@
 import 'package:localstore/localstore.dart';
 
 import 'base_downloader.dart';
+import 'exceptions.dart';
 import 'models.dart';
 
 /// Persistent database used for tracking task status and progress.
@@ -110,9 +111,9 @@ class TaskRecord {
   final Task task;
   final TaskStatus taskStatus;
   final double progress;
-  final TaskError? error;
+  final TaskException? exception;
 
-  TaskRecord(this.task, this.taskStatus, this.progress, [this.error]);
+  TaskRecord(this.task, this.taskStatus, this.progress, [this.exception]);
 
   /// Returns the group collection this record is stored under, which is
   /// the [task]'s [Task.group]
@@ -126,30 +127,30 @@ class TaskRecord {
       : task = Task.createFromJsonMap(jsonMap),
         taskStatus = TaskStatus.values[jsonMap['status'] as int? ?? 0],
         progress = jsonMap['progress'] as double? ?? 0,
-        error = jsonMap['error'] == null
+        exception = jsonMap['exception'] == null
             ? null
-            : TaskError.fromJsonMap(jsonMap['error']);
+            : TaskException.fromJsonMap(jsonMap['error']);
 
   /// Returns JSON map representation of this [TaskRecord]
   ///
-  /// Note the [taskStatus], [progress] and [error] fields are merged into
+  /// Note the [taskStatus], [progress] and [exception] fields are merged into
   /// the JSON map representation of the [task]
   Map<String, dynamic> toJsonMap() {
     final jsonMap = task.toJsonMap();
     jsonMap['status'] = taskStatus.index;
     jsonMap['progress'] = progress;
-    jsonMap['error'] = error?.toJsonMap();
+    jsonMap['exception'] = exception?.toJsonMap();
     return jsonMap;
   }
 
-  /// Copy with optional replacements. [error] is always copied
+  /// Copy with optional replacements. [exception] is always copied
   TaskRecord copyWith({Task? task, TaskStatus? taskStatus, double? progress}) =>
       TaskRecord(task ?? this.task, taskStatus ?? this.taskStatus,
-          progress ?? this.progress, error);
+          progress ?? this.progress, exception);
 
   @override
   String toString() {
-    return 'DatabaseRecord{task: $task, status: $taskStatus, progress: $progress, error: $error}';
+    return 'DatabaseRecord{task: $task, status: $taskStatus, progress: $progress, exception: $exception}';
   }
 
   @override
@@ -160,9 +161,9 @@ class TaskRecord {
           task == other.task &&
           taskStatus == other.taskStatus &&
           progress == other.progress &&
-          error == other.error;
+          exception == other.exception;
 
   @override
   int get hashCode =>
-      task.hashCode ^ taskStatus.hashCode ^ progress.hashCode ^ error.hashCode;
+      task.hashCode ^ taskStatus.hashCode ^ progress.hashCode ^ exception.hashCode;
 }

--- a/lib/src/database.dart
+++ b/lib/src/database.dart
@@ -143,10 +143,7 @@ class TaskRecord {
   }
 
   /// Copy with optional replacements. [error] is always copied
-  TaskRecord copyWith(
-          {Task? task,
-          TaskStatus? taskStatus,
-          double? progress}) =>
+  TaskRecord copyWith({Task? task, TaskStatus? taskStatus, double? progress}) =>
       TaskRecord(task ?? this.task, taskStatus ?? this.taskStatus,
           progress ?? this.progress, error);
 

--- a/lib/src/database.dart
+++ b/lib/src/database.dart
@@ -110,37 +110,49 @@ class TaskRecord {
   final Task task;
   final TaskStatus taskStatus;
   final double progress;
+  final TaskError? error;
 
-  TaskRecord(this.task, this.taskStatus, this.progress);
+  TaskRecord(this.task, this.taskStatus, this.progress, [this.error]);
 
-  /// Returns the group collection this record is stored under
+  /// Returns the group collection this record is stored under, which is
+  /// the [task]'s [Task.group]
   String get group => task.group;
 
-  /// Returns the record id
+  /// Returns the record id, which is the [task]'s [Task.taskId]
   String get taskId => task.taskId;
 
   /// Create [TaskRecord] from a JSON map
   TaskRecord.fromJsonMap(Map<String, dynamic> jsonMap)
       : task = Task.createFromJsonMap(jsonMap),
-        taskStatus = TaskStatus.values[jsonMap['status'] as int],
-        progress = jsonMap['progress'];
+        taskStatus = TaskStatus.values[jsonMap['status'] as int? ?? 0],
+        progress = jsonMap['progress'] as double? ?? 0,
+        error = jsonMap['error'] == null
+            ? null
+            : TaskError.fromJsonMap(jsonMap['error']);
 
   /// Returns JSON map representation of this [TaskRecord]
+  ///
+  /// Note the [taskStatus], [progress] and [error] fields are merged into
+  /// the JSON map representation of the [task]
   Map<String, dynamic> toJsonMap() {
     final jsonMap = task.toJsonMap();
     jsonMap['status'] = taskStatus.index;
     jsonMap['progress'] = progress;
+    jsonMap['error'] = error?.toJsonMap();
     return jsonMap;
   }
 
-  /// Copy with optional replacements
-  TaskRecord copyWith({Task? task, TaskStatus? taskStatus, double? progress}) =>
+  /// Copy with optional replacements. [error] is always copied
+  TaskRecord copyWith(
+          {Task? task,
+          TaskStatus? taskStatus,
+          double? progress}) =>
       TaskRecord(task ?? this.task, taskStatus ?? this.taskStatus,
-          progress ?? this.progress);
+          progress ?? this.progress, error);
 
   @override
   String toString() {
-    return 'DatabaseRecord{task: $task, status: $taskStatus, progress: $progress}';
+    return 'DatabaseRecord{task: $task, status: $taskStatus, progress: $progress, error: $error}';
   }
 
   @override
@@ -150,8 +162,10 @@ class TaskRecord {
           runtimeType == other.runtimeType &&
           task == other.task &&
           taskStatus == other.taskStatus &&
-          progress == other.progress;
+          progress == other.progress &&
+          error == other.error;
 
   @override
-  int get hashCode => task.hashCode ^ taskStatus.hashCode ^ progress.hashCode;
+  int get hashCode =>
+      task.hashCode ^ taskStatus.hashCode ^ progress.hashCode ^ error.hashCode;
 }

--- a/lib/src/database.dart
+++ b/lib/src/database.dart
@@ -109,11 +109,11 @@ class Database {
 /// storage if [trackTasks] has been called to activate this.
 class TaskRecord {
   final Task task;
-  final TaskStatus taskStatus;
+  final TaskStatus status;
   final double progress;
   final TaskException? exception;
 
-  TaskRecord(this.task, this.taskStatus, this.progress, [this.exception]);
+  TaskRecord(this.task, this.status, this.progress, [this.exception]);
 
   /// Returns the group collection this record is stored under, which is
   /// the [task]'s [Task.group]
@@ -125,7 +125,7 @@ class TaskRecord {
   /// Create [TaskRecord] from a JSON map
   TaskRecord.fromJsonMap(Map<String, dynamic> jsonMap)
       : task = Task.createFromJsonMap(jsonMap),
-        taskStatus = TaskStatus.values[jsonMap['status'] as int? ?? 0],
+        status = TaskStatus.values[jsonMap['status'] as int? ?? 0],
         progress = jsonMap['progress'] as double? ?? 0,
         exception = jsonMap['exception'] == null
             ? null
@@ -133,24 +133,24 @@ class TaskRecord {
 
   /// Returns JSON map representation of this [TaskRecord]
   ///
-  /// Note the [taskStatus], [progress] and [exception] fields are merged into
+  /// Note the [status], [progress] and [exception] fields are merged into
   /// the JSON map representation of the [task]
   Map<String, dynamic> toJsonMap() {
     final jsonMap = task.toJsonMap();
-    jsonMap['status'] = taskStatus.index;
+    jsonMap['status'] = status.index;
     jsonMap['progress'] = progress;
     jsonMap['exception'] = exception?.toJsonMap();
     return jsonMap;
   }
 
   /// Copy with optional replacements. [exception] is always copied
-  TaskRecord copyWith({Task? task, TaskStatus? taskStatus, double? progress}) =>
-      TaskRecord(task ?? this.task, taskStatus ?? this.taskStatus,
+  TaskRecord copyWith({Task? task, TaskStatus? status, double? progress}) =>
+      TaskRecord(task ?? this.task, status ?? this.status,
           progress ?? this.progress, exception);
 
   @override
   String toString() {
-    return 'DatabaseRecord{task: $task, status: $taskStatus, progress: $progress, exception: $exception}';
+    return 'DatabaseRecord{task: $task, status: $status, progress: $progress, exception: $exception}';
   }
 
   @override
@@ -159,11 +159,11 @@ class TaskRecord {
       other is TaskRecord &&
           runtimeType == other.runtimeType &&
           task == other.task &&
-          taskStatus == other.taskStatus &&
+          status == other.status &&
           progress == other.progress &&
           exception == other.exception;
 
   @override
   int get hashCode =>
-      task.hashCode ^ taskStatus.hashCode ^ progress.hashCode ^ exception.hashCode;
+      task.hashCode ^ status.hashCode ^ progress.hashCode ^ exception.hashCode;
 }

--- a/lib/src/database.dart
+++ b/lib/src/database.dart
@@ -129,7 +129,7 @@ class TaskRecord {
         progress = jsonMap['progress'] as double? ?? 0,
         exception = jsonMap['exception'] == null
             ? null
-            : TaskException.fromJsonMap(jsonMap['error']);
+            : TaskException.fromJsonMap(jsonMap['exception']);
 
   /// Returns JSON map representation of this [TaskRecord]
   ///

--- a/lib/src/desktop_downloader.dart
+++ b/lib/src/desktop_downloader.dart
@@ -122,7 +122,7 @@ class DesktopDownloader extends BaseDownloader {
             case 'statusUpdate':
               final status = message[1] as TaskStatus;
               processStatusUpdate(task, status, status == TaskStatus.failed ?
-              message[1] as TaskError : null);
+              message[2] as TaskError : null);
               break;
 
             case 'resumeData':

--- a/lib/src/desktop_downloader.dart
+++ b/lib/src/desktop_downloader.dart
@@ -90,8 +90,8 @@ class DesktopDownloader extends BaseDownloader {
     errorPort.listen((message) {
       final exceptionDescription = (message as List).first as String;
       logError(task, exceptionDescription);
-      processStatusUpdate(TaskStatusUpdate(task, TaskStatus.failed,
-          TaskException(exceptionDescription)));
+      processStatusUpdate(TaskStatusUpdate(
+          task, TaskStatus.failed, TaskException(exceptionDescription)));
       receivePort.close(); // also ends listener at then end
     });
     await Isolate.spawn(doTask, receivePort.sendPort,
@@ -122,8 +122,12 @@ class DesktopDownloader extends BaseDownloader {
           switch (message[0] as String) {
             case 'statusUpdate':
               final status = message[1] as TaskStatus;
-              processStatusUpdate(TaskStatusUpdate(task, status,
-                  status == TaskStatus.failed ? message[2] as TaskException : null));
+              processStatusUpdate(TaskStatusUpdate(
+                  task,
+                  status,
+                  status == TaskStatus.failed
+                      ? message[2] as TaskException
+                      : null));
               break;
 
             case 'resumeData':

--- a/lib/src/desktop_downloader.dart
+++ b/lib/src/desktop_downloader.dart
@@ -121,8 +121,8 @@ class DesktopDownloader extends BaseDownloader {
           switch (message[0] as String) {
             case 'statusUpdate':
               final status = message[1] as TaskStatus;
-              processStatusUpdate(task, status, status == TaskStatus.failed ?
-              message[2] as TaskError : null);
+              processStatusUpdate(task, status,
+                  status == TaskStatus.failed ? message[2] as TaskError : null);
               break;
 
             case 'resumeData':
@@ -131,8 +131,8 @@ class DesktopDownloader extends BaseDownloader {
               break;
 
             default:
-              throw ArgumentError('Did not recognize message: ${message[0] as
-               String}');
+              throw ArgumentError(
+                  'Did not recognize message: ${message[0] as String}');
           }
         } else if (message is String) {
           // log message

--- a/lib/src/desktop_downloader.dart
+++ b/lib/src/desktop_downloader.dart
@@ -43,6 +43,12 @@ class DesktopDownloader extends BaseDownloader {
   @override
   Future<bool> enqueue(Task task,
       [TaskNotificationConfig? notificationConfig]) async {
+    try {
+      Uri.decodeFull(task.url);
+    } catch (e) {
+      _log.fine('Invalid url: ${task.url} error: $e');
+      return false;
+    }
     super.enqueue(task);
     _queue.add(task);
     processStatusUpdate(task, TaskStatus.enqueued);

--- a/lib/src/desktop_downloader.dart
+++ b/lib/src/desktop_downloader.dart
@@ -12,6 +12,7 @@ import 'package:path_provider/path_provider.dart';
 
 import 'base_downloader.dart';
 import 'desktop_downloader_isolate.dart';
+import 'exceptions.dart';
 import 'file_downloader.dart';
 import 'models.dart';
 
@@ -90,7 +91,7 @@ class DesktopDownloader extends BaseDownloader {
       final error = (message as List).first as String;
       logError(task, error);
       processStatusUpdate(task, TaskStatus.failed,
-          TaskError(ErrorType.general, description: error));
+          TaskException(error));
       receivePort.close(); // also ends listener at then end
     });
     await Isolate.spawn(doTask, receivePort.sendPort,
@@ -122,7 +123,7 @@ class DesktopDownloader extends BaseDownloader {
             case 'statusUpdate':
               final status = message[1] as TaskStatus;
               processStatusUpdate(task, status,
-                  status == TaskStatus.failed ? message[2] as TaskError : null);
+                  status == TaskStatus.failed ? message[2] as TaskException : null);
               break;
 
             case 'resumeData':

--- a/lib/src/desktop_downloader_isolate.dart
+++ b/lib/src/desktop_downloader_isolate.dart
@@ -80,7 +80,7 @@ Future<void> doTask(SendPort sendPort) async {
   Isolate.exit();
 }
 
-/// Do the POST or GET based download task
+/// Execute the download task
 ///
 /// Sends updates via the [sendPort] and can be commanded to cancel/pause via
 /// the [messagesToIsolate] queue
@@ -94,9 +94,7 @@ Future<void> doDownloadTask(
   isResume = isResume &&
       await determineIfResumeIsPossible(tempFilePath, requiredStartByte);
   final client = DesktopDownloader.httpClient;
-  var request = task.post == null
-      ? http.Request('GET', Uri.parse(task.url))
-      : http.Request('POST', Uri.parse(task.url));
+  var request = http.Request(task.httpRequestMethod, Uri.parse(task.url));
   request.headers.addAll(task.headers);
   if (isResume) {
     request.headers['Range'] = 'bytes=$requiredStartByte-';
@@ -335,7 +333,7 @@ Future<void> doUploadTask(
   var resultStatus = TaskStatus.failed;
   try {
     final client = DesktopDownloader.httpClient;
-    final request = http.StreamedRequest('POST', Uri.parse(task.url));
+    final request = http.StreamedRequest(task.httpRequestMethod, Uri.parse(task.url));
     request.headers.addAll(task.headers);
     request.contentLength = contentLength;
     if (isBinaryUpload) {

--- a/lib/src/desktop_downloader_isolate.dart
+++ b/lib/src/desktop_downloader_isolate.dart
@@ -260,6 +260,7 @@ Future<bool> prepareResume(
   final total = int.parse(matchResult.group(3) ?? '0');
   final tempFile = File(tempFilePath);
   final tempFileLength = await tempFile.length();
+  _log.finest('Resume start=$start, end=$end of total=$total bytes, tempFile = $tempFileLength bytes');
   if (total != end + 1 || start > tempFileLength) {
     _log.fine('Offered range not feasible: $range');
     taskError = TaskError(ErrorType.resume,

--- a/lib/src/desktop_downloader_isolate.dart
+++ b/lib/src/desktop_downloader_isolate.dart
@@ -114,11 +114,11 @@ Future<void> doDownloadTask(
         // determine if this task can be paused
         final acceptRangesHeader = response.headers['accept-ranges'];
         taskCanResume =
-          acceptRangesHeader == 'bytes' || response.statusCode == 206;
+            acceptRangesHeader == 'bytes' || response.statusCode == 206;
         sendPort.send(taskCanResume);
       }
-    isResume =
-        isResume && response.statusCode == 206; // confirm resume response
+      isResume =
+          isResume && response.statusCode == 206; // confirm resume response
       if (okResponses.contains(response.statusCode)) {
         resultStatus = await processOkDownloadResponse(task, filePath,
             tempFilePath, taskCanResume, isResume, response, sendPort);
@@ -263,7 +263,8 @@ Future<bool> prepareResume(
   final total = int.parse(matchResult.group(3) ?? '0');
   final tempFile = File(tempFilePath);
   final tempFileLength = await tempFile.length();
-  _log.finest('Resume start=$start, end=$end of total=$total bytes, tempFile = $tempFileLength bytes');
+  _log.finest(
+      'Resume start=$start, end=$end of total=$total bytes, tempFile = $tempFileLength bytes');
   if (total != end + 1 || start > tempFileLength) {
     _log.fine('Offered range not feasible: $range');
     taskError = TaskError(ErrorType.resume,

--- a/lib/src/desktop_downloader_isolate.dart
+++ b/lib/src/desktop_downloader_isolate.dart
@@ -333,7 +333,8 @@ Future<void> doUploadTask(
   var resultStatus = TaskStatus.failed;
   try {
     final client = DesktopDownloader.httpClient;
-    final request = http.StreamedRequest(task.httpRequestMethod, Uri.parse(task.url));
+    final request =
+        http.StreamedRequest(task.httpRequestMethod, Uri.parse(task.url));
     request.headers.addAll(task.headers);
     request.contentLength = contentLength;
     if (isBinaryUpload) {

--- a/lib/src/exceptions.dart
+++ b/lib/src/exceptions.dart
@@ -38,7 +38,8 @@ class TaskException implements Exception {
   }
 
   /// Create object from String description of the type, and parameters
-  factory TaskException.fromTypeString(String typeString, String description, [int httpResponseCode = -1]) {
+  factory TaskException.fromTypeString(String typeString, String description,
+      [int httpResponseCode = -1]) {
     final exceptionType = _exceptions[typeString] ?? TaskException.new;
     if (typeString != 'TaskHttpException') {
       return exceptionType(description);
@@ -49,10 +50,7 @@ class TaskException implements Exception {
 
   /// Return JSON Map representing object
   Map<String, dynamic> toJsonMap() =>
-      {
-        'type': exceptionType,
-        'description': description
-      };
+      {'type': exceptionType, 'description': description};
 
   @override
   String toString() {
@@ -97,10 +95,8 @@ class TaskHttpException extends TaskException {
   String get exceptionType => 'TaskHttpException';
 
   @override
-  Map<String, dynamic> toJsonMap() => {
-    ...super.toJsonMap(),
-    'httpResponseCode': httpResponseCode
-  };
+  Map<String, dynamic> toJsonMap() =>
+      {...super.toJsonMap(), 'httpResponseCode': httpResponseCode};
 
   @override
   String toString() {

--- a/lib/src/exceptions.dart
+++ b/lib/src/exceptions.dart
@@ -1,0 +1,109 @@
+const _exceptions = {
+  'TaskException': TaskException.new,
+  'TaskFileSystemException': TaskFileSystemException.new,
+  'TaskUrlException': TaskUrlException.new,
+  'TaskConnectionException': TaskConnectionException.new,
+  'TaskResumeException': TaskResumeException.new,
+  'TaskHttpException': TaskHttpException.new
+};
+
+/// Contains Exception information associated with a failed [Task]
+///
+/// The [exceptionType] categorizes and describes the exception
+/// The [description] is typically taken from the platform-generated
+/// exception message, or from the plugin. The localization is undefined
+/// For the [TaskHttpException], the [httpResponseCode] is only valid if >0
+/// and may offer details about the nature of the error
+class TaskException implements Exception {
+  final String description;
+
+  TaskException(this.description);
+
+  String get exceptionType => 'TaskException';
+
+  /// Create object from JSON Map
+  factory TaskException.fromJsonMap(Map<String, dynamic> jsonMap) {
+    final typeString = jsonMap['type'] as String? ?? 'TaskException';
+    final exceptionType = _exceptions[typeString];
+    final description = jsonMap['description'] as String? ?? '';
+    if (exceptionType != null) {
+      if (typeString != 'TaskHttpException') {
+        return exceptionType(description);
+      } else {
+        final httpResponseCode = jsonMap['httpResponseCode'] as int? ?? -1;
+        return exceptionType(description, httpResponseCode);
+      }
+    }
+    return TaskException('Unknown');
+  }
+
+  /// Create object from String description of the type, and parameters
+  factory TaskException.fromTypeString(String typeString, String description, [int httpResponseCode = -1]) {
+    final exceptionType = _exceptions[typeString] ?? TaskException.new;
+    if (typeString != 'TaskHttpException') {
+      return exceptionType(description);
+    } else {
+      return exceptionType(description, httpResponseCode);
+    }
+  }
+
+  /// Return JSON Map representing object
+  Map<String, dynamic> toJsonMap() =>
+      {
+        'type': exceptionType,
+        'description': description
+      };
+
+  @override
+  String toString() {
+    return '$exceptionType: $description';
+  }
+}
+
+class TaskFileSystemException extends TaskException {
+  TaskFileSystemException(super.description);
+
+  @override
+  String get exceptionType => 'TaskFileSystemException';
+}
+
+class TaskUrlException extends TaskException {
+  TaskUrlException(super.description);
+
+  @override
+  String get exceptionType => 'TaskUrlException';
+}
+
+class TaskConnectionException extends TaskException {
+  TaskConnectionException(super.description);
+
+  @override
+  String get exceptionType => 'TaskConnectionException';
+}
+
+class TaskResumeException extends TaskException {
+  TaskResumeException(super.description);
+
+  @override
+  String get exceptionType => 'TaskResumeException';
+}
+
+class TaskHttpException extends TaskException {
+  final int httpResponseCode;
+
+  TaskHttpException(super.description, this.httpResponseCode);
+
+  @override
+  String get exceptionType => 'TaskHttpException';
+
+  @override
+  Map<String, dynamic> toJsonMap() => {
+    ...super.toJsonMap(),
+    'httpResponseCode': httpResponseCode
+  };
+
+  @override
+  String toString() {
+    return '$exceptionType, response code $httpResponseCode: $description';
+  }
+}

--- a/lib/src/file_downloader.dart
+++ b/lib/src/file_downloader.dart
@@ -92,14 +92,18 @@ class FileDownloader {
       TaskStatusCallbackWithError? taskStatusCallbackWithError,
       TaskProgressCallback? taskProgressCallback,
       TaskNotificationTapCallback? taskNotificationTapCallback}) {
-    assert(taskStatusCallback != null || taskProgressCallback != null ||
-        taskStatusCallbackWithError != null,
+    assert(
+        taskStatusCallback != null ||
+            taskProgressCallback != null ||
+            taskStatusCallbackWithError != null,
         'Must provide at least one callback');
-    assert(taskStatusCallback == null || taskStatusCallbackWithError == null,
-    'Must provide either taskStatusCallback or taskStatusCallbackWithError - '
+    assert(
+        taskStatusCallback == null || taskStatusCallbackWithError == null,
+        'Must provide either taskStatusCallback or taskStatusCallbackWithError - '
         'not both');
     if (taskStatusCallback != null || taskStatusCallbackWithError != null) {
-      _downloader.groupStatusCallbacks[group] = taskStatusCallback ?? taskStatusCallbackWithError;
+      _downloader.groupStatusCallbacks[group] =
+          taskStatusCallback ?? taskStatusCallbackWithError;
     }
     if (taskProgressCallback != null) {
       _downloader.groupProgressCallbacks[group] = taskProgressCallback;

--- a/lib/src/file_downloader.dart
+++ b/lib/src/file_downloader.dart
@@ -89,7 +89,7 @@ class FileDownloader {
   FileDownloader registerCallbacks(
       {String group = defaultGroup,
       TaskStatusCallback? taskStatusCallback,
-      TaskStatusCallbackWithError? taskStatusCallbackWithError,
+      TaskStatusCallbackWithException? taskStatusCallbackWithError,
       TaskProgressCallback? taskProgressCallback,
       TaskNotificationTapCallback? taskNotificationTapCallback}) {
     assert(

--- a/lib/src/file_downloader.dart
+++ b/lib/src/file_downloader.dart
@@ -412,9 +412,31 @@ class FileDownloader {
   /// listener or callbacks, and call [trackTasks] for each group.
   ///
   /// Returns the [FileDownloader] for easy chaining
-  Future<FileDownloader> trackTasks(
-      {String group = defaultGroup, bool markDownloadedComplete = true}) async {
+  Future<FileDownloader> trackTasksInGroup(
+      String group, {bool markDownloadedComplete = true}) async {
     await _downloader.trackTasks(group, markDownloadedComplete);
+    return this;
+  }
+
+  /// Activate tracking for all tasks
+  ///
+  /// All subsequent tasks will be recorded in persistent storage.
+  /// Use the [FileDownloader.database] to get or remove [TaskRecord] objects,
+  /// which contain a [Task], its [TaskStatus] and a [double] for progress.
+  ///
+  /// If [markDownloadedComplete] is true (default) then all tasks in the
+  /// database that are marked as not yet [TaskStatus.complete] will be set to
+  /// [TaskStatus.complete] if the target file for that task exists.
+  /// They will also emit [TaskStatus.complete] and [progressComplete] to
+  /// their registered listener or callback.
+  /// This is a convenient way to capture downloads that have completed while
+  /// the app was suspended: on app startup, immediately register your
+  /// listener or callbacks, and call [trackTasks] for each group.
+  ///
+  /// Returns the [FileDownloader] for easy chaining
+  Future<FileDownloader> trackTasks(
+      {bool markDownloadedComplete = true}) async {
+    await _downloader.trackTasks(null, markDownloadedComplete);
     return this;
   }
 

--- a/lib/src/file_downloader.dart
+++ b/lib/src/file_downloader.dart
@@ -83,11 +83,16 @@ class FileDownloader {
   FileDownloader registerCallbacks(
       {String group = defaultGroup,
       TaskStatusCallback? taskStatusCallback,
+      TaskStatusCallbackWithError? taskStatusCallbackWithError,
       TaskProgressCallback? taskProgressCallback}) {
-    assert(taskStatusCallback != null || (taskProgressCallback != null),
-        'Must provide a TaskStatusCallback or a TaskProgressCallback, or both');
-    if (taskStatusCallback != null) {
-      _downloader.groupStatusCallbacks[group] = taskStatusCallback;
+    assert(taskStatusCallback != null || taskProgressCallback != null ||
+        taskStatusCallbackWithError != null,
+        'Must provide at least one callback');
+    assert(taskStatusCallback == null || taskStatusCallbackWithError == null,
+    'Must provide either taskStatusCallback or taskStatusCallbackWithError - '
+        'not both');
+    if (taskStatusCallback != null || taskStatusCallbackWithError != null) {
+      _downloader.groupStatusCallbacks[group] = taskStatusCallback ?? taskStatusCallbackWithError;
     }
     if (taskProgressCallback != null) {
       _downloader.groupProgressCallbacks[group] = taskProgressCallback;

--- a/lib/src/models.dart
+++ b/lib/src/models.dart
@@ -124,8 +124,8 @@ typedef TaskStatusCallback = void Function(Task task, TaskStatus status);
 /// Signature for a function you can register to be called
 /// when the state of a [task] changes, and are interested in detailed
 /// error information for failed tasks.
-typedef TaskStatusCallbackWithError = void Function(Task task, TaskStatus
-status, TaskError? taskError);
+typedef TaskStatusCallbackWithError = void Function(
+    Task task, TaskStatus status, TaskError? taskError);
 
 /// Signature for a function you can register to be called
 /// for every progress change of a [task].
@@ -980,11 +980,36 @@ class TaskError {
   final int httpResponseCode;
   final String description;
 
-  TaskError(this.type, {this.httpResponseCode = -1,
-    this.description = ''});
+  TaskError(this.type, {this.httpResponseCode = -1, this.description = ''});
+
+  /// Create object from JSON Map
+  TaskError.fromJsonMap(Map<String, dynamic> jsonMap)
+      : type = ErrorType.values[jsonMap['type'] as int? ?? 0],
+        httpResponseCode = jsonMap['httpResponseCode'] as int? ?? 0,
+        description = jsonMap['description'] ?? '';
+
+  /// Return JSON Map representing object
+  Map<String, dynamic> toJsonMap() => {
+        'type': type.index,
+        'httpResponseCode': httpResponseCode,
+        'description': description
+      };
 
   @override
   String toString() {
     return 'TaskError{type: $type, httpResponseCode: $httpResponseCode, description: $description}';
   }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is TaskError &&
+          runtimeType == other.runtimeType &&
+          type == other.type &&
+          httpResponseCode == other.httpResponseCode &&
+          description == other.description;
+
+  @override
+  int get hashCode =>
+      type.hashCode ^ httpResponseCode.hashCode ^ description.hashCode;
 }

--- a/lib/src/models.dart
+++ b/lib/src/models.dart
@@ -892,4 +892,9 @@ class TaskError {
 
   TaskError(this.type, {this.httpResponseCode = -1,
     this.description = ''});
+
+  @override
+  String toString() {
+    return 'TaskError{type: $type, httpResponseCode: $httpResponseCode, description: $description}';
+  }
 }

--- a/lib/src/models.dart
+++ b/lib/src/models.dart
@@ -118,6 +118,12 @@ enum Updates {
 typedef TaskStatusCallback = void Function(Task task, TaskStatus status);
 
 /// Signature for a function you can register to be called
+/// when the state of a [task] changes, and are interested in detailed
+/// error information for failed tasks.
+typedef TaskStatusCallbackWithError = void Function(Task task, TaskStatus
+status, TaskError? taskError);
+
+/// Signature for a function you can register to be called
 /// for every progress change of a [task].
 ///
 /// A successfully completed task will always finish with progress 1.0
@@ -850,4 +856,40 @@ enum SharedStorage {
 
   /// Android-only: the 'external storage' directory
   external
+}
+
+enum ErrorType {
+  /// Invalid HTTP response
+  httpResponse,
+
+  /// Could not save or find file, or create directory
+  fileSystem,
+
+  /// URL incorrect
+  url,
+
+  /// Connection problem, eg host not found, timeout
+  connection,
+
+  /// Could not resume or pause task
+  resume,
+
+  /// General error
+  general
+}
+
+/// Contains error information associated with a failed [Task]
+///
+/// The [type] categorizes the error
+/// The [httpResponseCode] is only valid if >0 and may offer details about the
+/// nature of the error
+/// The [description] is typically taken from the platform-generated
+/// error message, or from the plugin. The localization is undefined
+class TaskError {
+  final ErrorType type;
+  final int httpResponseCode;
+  final String description;
+
+  TaskError(this.type, {this.httpResponseCode = -1,
+    this.description = ''});
 }

--- a/lib/src/models.dart
+++ b/lib/src/models.dart
@@ -822,8 +822,9 @@ class TaskUpdate {
 /// A status update event
 class TaskStatusUpdate extends TaskUpdate {
   final TaskStatus status;
+  final TaskError? error;
 
-  TaskStatusUpdate(super.task, this.status);
+  TaskStatusUpdate(super.task, this.status, [this.error]);
 }
 
 /// A progress update event

--- a/lib/src/models.dart
+++ b/lib/src/models.dart
@@ -120,7 +120,7 @@ enum Updates {
 }
 
 /// Signature for a function you can register to be called
-/// when the state of a [task] changes.
+/// when the status of a [task] changes.
 typedef TaskStatusCallback = void Function(TaskStatusUpdate update);
 
 /// Signature for a function you can register to be called
@@ -835,7 +835,7 @@ class Batch {
   int get numFailed => results.values.length - numSucceeded;
 }
 
-/// Base class for events related to [task]. Actual events are
+/// Base class for updates related to [task]. Actual updates are
 /// either a status update or a progress update.
 ///
 /// When receiving an update, test if the update is a
@@ -847,7 +847,10 @@ class TaskUpdate {
   const TaskUpdate(this.task);
 }
 
-/// A status update event
+/// A status update
+///
+/// Contains [TaskStatus] and, if [TaskStatus.failed] possibly a
+/// [TaskException]
 class TaskStatusUpdate extends TaskUpdate {
   final TaskStatus status;
   final TaskException? exception;
@@ -855,9 +858,10 @@ class TaskStatusUpdate extends TaskUpdate {
   const TaskStatusUpdate(super.task, this.status, [this.exception]);
 }
 
-/// A progress update event
+/// A progress update
 ///
 /// A successfully downloaded task will always finish with progress 1.0
+///
 /// [TaskStatus.failed] results in progress -1.0
 /// [TaskStatus.canceled] results in progress -2.0
 /// [TaskStatus.notFound] results in progress -3.0

--- a/lib/src/models.dart
+++ b/lib/src/models.dart
@@ -121,13 +121,7 @@ enum Updates {
 
 /// Signature for a function you can register to be called
 /// when the state of a [task] changes.
-typedef TaskStatusCallback = void Function(Task task, TaskStatus status);
-
-/// Signature for a function you can register to be called
-/// when the state of a [task] changes, and are interested in detailed
-/// exception information for failed tasks.
-typedef TaskStatusCallbackWithException = void Function(
-    Task task, TaskStatus status, TaskException? taskException);
+typedef TaskStatusCallback = void Function(TaskStatusUpdate update);
 
 /// Signature for a function you can register to be called
 /// for every progress change of a [task].
@@ -138,7 +132,7 @@ typedef TaskStatusCallbackWithException = void Function(
 /// [TaskStatus.notFound] results in progress -3.0
 /// [TaskStatus.waitingToRetry] results in progress -4.0
 /// These constants are available as [progressFailed] etc
-typedef TaskProgressCallback = void Function(Task task, double progress);
+typedef TaskProgressCallback = void Function(TaskProgressUpdate update);
 
 /// Signature for function you can register to be called when a notification
 /// is tapped by the user
@@ -818,7 +812,7 @@ class Batch {
 class TaskUpdate {
   final Task task;
 
-  TaskUpdate(this.task);
+  const TaskUpdate(this.task);
 }
 
 /// A status update event
@@ -826,7 +820,7 @@ class TaskStatusUpdate extends TaskUpdate {
   final TaskStatus status;
   final TaskException? exception;
 
-  TaskStatusUpdate(super.task, this.status, [this.exception]);
+  const TaskStatusUpdate(super.task, this.status, [this.exception]);
 }
 
 /// A progress update event
@@ -839,7 +833,7 @@ class TaskStatusUpdate extends TaskUpdate {
 class TaskProgressUpdate extends TaskUpdate {
   final double progress;
 
-  TaskProgressUpdate(super.task, this.progress);
+  const TaskProgressUpdate(super.task, this.progress);
 }
 
 // Progress values representing a status
@@ -856,7 +850,7 @@ class ResumeData {
   final String data;
   final int requiredStartByte;
 
-  ResumeData(this.task, this.data, this.requiredStartByte);
+  const ResumeData(this.task, this.data, this.requiredStartByte);
 
   /// Create object from JSON Map
   ResumeData.fromJsonMap(Map<String, dynamic> jsonMap)
@@ -894,7 +888,7 @@ class TaskNotification {
   final String title;
   final String body;
 
-  TaskNotification(this.title, this.body);
+  const TaskNotification(this.title, this.body);
 
   /// Return JSON Map representing object
   Map<String, dynamic> toJsonMap() => {"title": title, "body": body};

--- a/lib/src/models.dart
+++ b/lib/src/models.dart
@@ -453,7 +453,8 @@ abstract class Task extends Request {
 
   @override
   String toString() {
-    return 'Task{taskId: $taskId, url: $url, filename: $filename, headers: $headers, post: ${post == null ? "null" : "not null"}, directory: $directory, baseDirectory: $baseDirectory, group: $group, updates: $updates, requiresWiFi: $requiresWiFi, retries: $retries, retriesRemaining: $retriesRemaining, metaData: $metaData}';
+    return 'Task{taskId: $taskId, url: $url, filename: $filename, headers: '
+        '$headers, httpRequestMethod: $httpRequestMethod, post: ${post == null ? "null" : "not null"}, directory: $directory, baseDirectory: $baseDirectory, group: $group, updates: $updates, requiresWiFi: $requiresWiFi, retries: $retries, retriesRemaining: $retriesRemaining, metaData: $metaData}';
   }
 }
 
@@ -493,7 +494,7 @@ class DownloadTask extends Task {
       super.urlQueryParameters,
       String? filename,
       super.headers,
-        super.httpRequestMethod,
+      super.httpRequestMethod,
       super.post,
       super.directory,
       super.baseDirectory,
@@ -524,7 +525,7 @@ class DownloadTask extends Task {
           String? url,
           String? filename,
           Map<String, String>? headers,
-            String? httpRequestMethod,
+          String? httpRequestMethod,
           Object? post,
           String? directory,
           BaseDirectory? baseDirectory,
@@ -689,7 +690,7 @@ class UploadTask extends Task {
       super.urlQueryParameters,
       required String filename,
       super.headers,
-        super.httpRequestMethod,
+      String? httpRequestMethod,
       String? post,
       this.fileField = 'file',
       String? mimeType,
@@ -711,7 +712,11 @@ class UploadTask extends Task {
         fields = fields ?? {},
         mimeType =
             mimeType ?? lookupMimeType(filename) ?? 'application/octet-stream',
-        super(taskId: taskId, filename: filename, post: post) {
+        super(
+            taskId: taskId,
+            filename: filename,
+            httpRequestMethod: httpRequestMethod ?? 'POST',
+            post: post) {
     if (allowPause) {
       throw ArgumentError('Uploads cannot be paused-> Set `allowPause` to '
           'false');
@@ -744,7 +749,7 @@ class UploadTask extends Task {
           String? url,
           String? filename,
           Map<String, String>? headers,
-          String?  httpRequestMethod,
+          String? httpRequestMethod,
           Object? post,
           String? fileField,
           String? mimeType,

--- a/lib/src/native_downloader.dart
+++ b/lib/src/native_downloader.dart
@@ -35,18 +35,13 @@ class NativeDownloader extends BaseDownloader {
       final task = Task.createFromJsonMap(jsonDecode(args.first as String));
       switch (call.method) {
         case 'statusUpdate':
-          // either simple int, or list with error data
-          final taskStatus = args.last is int
-              ? TaskStatus.values[args.last]
-              : TaskStatus.values[(args.last as List).first as int];
+          // int followed optionally followed by error data
+          final taskStatus = TaskStatus.values[args[1]];
           TaskError? taskError;
           if (taskStatus == TaskStatus.failed) {
-            // list is: [TaskStatus ordinal, errorType ordinal, http
-            // response code, description]
-            final argList = args.last as List;
-            taskError = TaskError(ErrorType.values[argList[1] as int],
-                httpResponseCode: argList[2],
-                description: argList[3]);
+            taskError = TaskError(ErrorType.values[args[2]],
+                httpResponseCode: args[3],
+                description: args[4]);
           }
           processStatusUpdate(task, taskStatus, taskError);
           break;

--- a/lib/src/native_downloader.dart
+++ b/lib/src/native_downloader.dart
@@ -6,6 +6,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
 import 'base_downloader.dart';
+import 'exceptions.dart';
 import 'models.dart';
 
 /// Implementation of download functionality for native platforms
@@ -35,14 +36,13 @@ class NativeDownloader extends BaseDownloader {
       final task = Task.createFromJsonMap(jsonDecode(args.first as String));
       switch (call.method) {
         case 'statusUpdate':
-          // int followed optionally followed by error data
+          // int followed optionally followed by exception data
           final taskStatus = TaskStatus.values[args[1]];
-          TaskError? taskError;
+          TaskException? taskException;
           if (taskStatus == TaskStatus.failed) {
-            taskError = TaskError(ErrorType.values[args[2]],
-                httpResponseCode: args[3], description: args[4]);
+            taskException = TaskException.fromTypeString(args[2] as String, args[3] as String, args[4] as int);
           }
-          processStatusUpdate(task, taskStatus, taskError);
+          processStatusUpdate(task, taskStatus, taskException);
           break;
 
         case 'progressUpdate':

--- a/lib/src/native_downloader.dart
+++ b/lib/src/native_downloader.dart
@@ -37,17 +37,17 @@ class NativeDownloader extends BaseDownloader {
       switch (call.method) {
         case 'statusUpdate':
           // int followed optionally followed by exception data
-          final taskStatus = TaskStatus.values[args[1]];
-          TaskException? taskException;
-          if (taskStatus == TaskStatus.failed) {
-            taskException = TaskException.fromTypeString(args[2] as String, args[3] as String, args[4] as int);
+          final status = TaskStatus.values[args[1]];
+          TaskException? exception;
+          if (status == TaskStatus.failed) {
+            exception = TaskException.fromTypeString(args[2] as String, args[3] as String, args[4] as int);
           }
-          processStatusUpdate(task, taskStatus, taskException);
+          processStatusUpdate(TaskStatusUpdate(task, status, exception));
           break;
 
         case 'progressUpdate':
           final progress = args.last as double;
-          processProgressUpdate(task, progress);
+          processProgressUpdate(TaskProgressUpdate(task, progress));
           break;
 
         case 'canResume':

--- a/lib/src/native_downloader.dart
+++ b/lib/src/native_downloader.dart
@@ -40,8 +40,7 @@ class NativeDownloader extends BaseDownloader {
           TaskError? taskError;
           if (taskStatus == TaskStatus.failed) {
             taskError = TaskError(ErrorType.values[args[2]],
-                httpResponseCode: args[3],
-                description: args[4]);
+                httpResponseCode: args[3], description: args[4]);
           }
           processStatusUpdate(task, taskStatus, taskError);
           break;

--- a/lib/src/native_downloader.dart
+++ b/lib/src/native_downloader.dart
@@ -40,7 +40,8 @@ class NativeDownloader extends BaseDownloader {
           final status = TaskStatus.values[args[1]];
           TaskException? exception;
           if (status == TaskStatus.failed) {
-            exception = TaskException.fromTypeString(args[2] as String, args[3] as String, args[4] as int);
+            exception = TaskException.fromTypeString(
+                args[2] as String, args[3] as String, args[4] as int);
           }
           processStatusUpdate(TaskStatusUpdate(task, status, exception));
           break;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: background_downloader
 description: A multi-platform background file downloader and uploader. Define the task, enqueue and monitor progress
 
-version: 5.6.0
+version: 6.0.0
 repository: https://github.com/781flyingdutchman/background_downloader
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: background_downloader
 description: A multi-platform background file downloader and uploader. Define the task, enqueue and monitor progress
 
-version: 5.4.4
+version: 5.4.5
 repository: https://github.com/781flyingdutchman/background_downloader
 
 environment:


### PR DESCRIPTION
Fixes #29 #33 #43 #44

Breaking changes:
* The `TaskStatusCallback` and `TaskProgressCallback` now take a single argument (`TaskStatusUpdate` and `TaskProgressUpdate` respectively) instead of multiple arguments. This aligns the callback API with the `updates` listener API, and makes it easier to add data to an update in the future. For example, in this version we add an `exception` property to programmatically handle exceptions
* Similarly, the `download` and `upload` methods now return a `TaskStatusUpdate` instead of a `TaskStatus`
* For consistency, the `taskStatus` property of the `TaskRecord` (used to store task information in a persistent database) is renamed to `status`
* The `trackTasks` method no longer takes a `group` argument, and starts tracking for all tasks, regardless of group. If you need tracking only for a specific group, call the new `trackTasksInGroup` method

Other changes (non-breaking):
* You can override the `httpRequestMethod` used for requests by setting it in the `Request`, `DownloadTask` or `UploadTask`. By default, requests and downloads use GET (unless `post` is set) and uploads use PUT
* The `download`, `upload`, `downloadBatch` and `uploadBatch` methods now take an optional `onElapsedTime` callback that is called at regular intervals (defined by the optional `elapsedTimeInterval` which defaults to 5 seconds) with the time elapsed since the call was made. This can be used to trigger UI warnings (e.g. 'this is taking rather long') or to cancel the task if it does not complete within a desired time. For performance reasons the `elapsedTimeInterval` should not be set to a value less than one second, and this mechanism should not be used to indicate progress.
* If a task fails, the `TaskStatusUpdate` will contain a `TaskException` that provides information about the type of exception (e.g. a `TaskFileSystemException` indicates an issue with storing or retrieving the file) and contains a `description` and (for `TaskHttpException` only) the `httpResponseCode`. If tasks are tracked, the  The following `TaskException` subtypes may occur:
  - `TaskException` (general exception)
  - `TaskFileSystemException` (issue retrieving or storing the file)
  - `TaskUrlException` (issue with the url)
  - `TaskConnectionException` (issue with the connection to the server)
  - `TaskResumeException` (issue with pausing or resuming a task)
  - `TaskHttpException` (issue with the HTTP connection, e.g. we received an error response from the server, captured in `httpResponseCode`)
