### PR TITLE
Fix #46 #48: unregisterCallBacks, resetUpdates, fix for DownloadTask.withSuggestedFilename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 6.1.0
+
+Added `unregisterCallBacks` to remove callbacks if you no longer want updates, and `resetUpdates` to reset the `updates` stream so it can be listened to again.
+
+Bug fix for `DownloadTask.withSuggestedFilename` for servers that do not follow case convention for the Content-Disposition header.
+
 ## 6.0.0
 
 Breaking changes:

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ A `DownloadTask` or `UploadTask` (both subclasses of `Task`) defines one downloa
     final result = await FileDownloader().download(task);  // do the download and wait for result
 ```
 
-The `result` will be a [TaskStatusUpdate](#https://pub.dev/documentation/background_downloader/latest/background_downloader/TaskStatusUpdate-class.html), which has a field `status` that indicates how the download ended: `.complete`, `.failed`, `.canceled` or `.notFound`. If the `status` is `.failed`, the `result.exception` field will contain a `TaskException` with information about what went wrong.
+The `result` will be a [TaskStatusUpdate](https://pub.dev/documentation/background_downloader/latest/background_downloader/TaskStatusUpdate-class.html), which has a field `status` that indicates how the download ended: `.complete`, `.failed`, `.canceled` or `.notFound`. If the `status` is `.failed`, the `result.exception` field will contain a `TaskException` with information about what went wrong.
 
 ### Monitoring the task
 
@@ -180,7 +180,7 @@ Listen to updates from the downloader by listening to the `updates` stream, and 
 
 Note that `successFullyEnqueued` only refers to the enqueueing of the download task, not its result, which must be monitored via the listener. Also note that in order to get progress updates the task must set its `updates` field to a value that includes progress updates. In the example, we are asking for both status and progress updates, but other combinations are possible. For example, if you set `updates` to `Updates.status` then the task will only generate status updates and no progress updates. You define what updates to receive on a task by task basis via the `Task.updates` field, which defaults to status updates only.
 
-You can start your subscription in a convenient place, like a widget's `initState`, and don't forget to cancel your subscription to the stream using `subscription.cancel()`. Note the stream can only be listened to once.
+You can start your subscription in a convenient place, like a widget's `initState`, and don't forget to cancel your subscription to the stream using `subscription.cancel()`. Note the stream can only be listened to once, though you can reset the stream controller by calling `await FileDownloader().resetUpdates()` to start listening again.
 
 ### Using callbacks
 
@@ -210,6 +210,8 @@ A basic file download with just status monitoring (no progress) then requires re
 You define what updates to receive on a task by task basis via the `Task.updates` field, which defaults to status updates only.  If you register a callback for a type of task, updates are provided only through that callback and will not be posted on the `updates` stream.
 
 Note that all tasks will call the same callback, unless you register separate callbacks for different [groups](#grouping-tasks) and set your `Task.group` field accordingly.
+
+You can unregister callbacks using `FileDownloader().unregisterCallbacks()`.
 
 ### Using the database to track Tasks
 
@@ -379,7 +381,7 @@ Because an app may require different types of downloads, and handle those differ
   final successFullyEnqueued = await FileDownloader().enqueue(task);
 ```
 
-The methods `registerCallBacks`, `reset`, `allTaskIds` and `allTasks` all take an optional `group` parameter to target tasks in a specific group. Note that if tasks are enqueued with a `group` other than default, calling any of these methods without a group parameter will not affect/include those tasks - only the default tasks.
+The methods `registerCallBacks`, `unregisterCallBacks`, `reset`, `allTaskIds` and `allTasks` all take an optional `group` parameter to target tasks in a specific group. Note that if tasks are enqueued with a `group` other than default, calling any of these methods without a group parameter will not affect/include those tasks - only the default tasks.
 
 If you listen to the `updates` stream instead of using callbacks, you can test for the task's `group` field in your listener, and process the update differently for different groups.
 

--- a/example/integration_test/database_test.dart
+++ b/example/integration_test/database_test.dart
@@ -1,7 +1,6 @@
 import 'dart:io';
 
 import 'package:background_downloader/background_downloader.dart';
-import 'package:background_downloader/src/database.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:localstore/localstore.dart';

--- a/lib/src/base_downloader.dart
+++ b/lib/src/base_downloader.dart
@@ -419,6 +419,15 @@ abstract class BaseDownloader {
     await _db.collection(modifiedTasksPath).doc(task.taskId).delete();
   }
 
+  /// Closes the [updates] stream and re-initializes the [StreamController]
+  /// such that the stream can be listened to again
+  Future<void> resetUpdatesStreamController() async {
+    if (updates.hasListener && !updates.isPaused) {
+      await updates.close();
+    }
+    updates = StreamController();
+  }
+
   /// Destroy - clears callbacks, updates stream and retry queue
   ///
   /// Clears all queues and references without sending cancellation
@@ -433,8 +442,7 @@ abstract class BaseDownloader {
     removeResumeData(); // removes all
     removePausedTask(); // removes all
     removeModifiedTask(); // removes all
-    updates.close();
-    updates = StreamController();
+    resetUpdatesStreamController();
   }
 
   /// Process status update coming from Downloader and emits to listener

--- a/lib/src/file_downloader.dart
+++ b/lib/src/file_downloader.dart
@@ -107,6 +107,33 @@ class FileDownloader {
     return this;
   }
 
+  /// Unregister a previously registered [TaskStatusCallback], [TaskProgressCallback]
+  /// or [TaskNotificationTapCallback].
+  ///
+  /// [group] defaults to the [FileDownloader.defaultGroup]
+  /// If [callback] is null, all callbacks for the [group] are unregistered
+  FileDownloader unregisterCallbacks(
+      {String group = defaultGroup, Function? callback}) {
+    if (callback != null) {
+      // remove specific callback
+      if (_downloader.groupStatusCallbacks[group] == callback) {
+        _downloader.groupStatusCallbacks.remove(group);
+      }
+      if (_downloader.groupProgressCallbacks[group] == callback) {
+        _downloader.groupProgressCallbacks.remove(group);
+      }
+      if (_downloader.groupNotificationTapCallbacks[group] == callback) {
+        _downloader.groupNotificationTapCallbacks.remove(group);
+      }
+    } else {
+      // remove all callbacks related to group
+      _downloader.groupStatusCallbacks.remove(group);
+      _downloader.groupProgressCallbacks.remove(group);
+      _downloader.groupNotificationTapCallbacks.remove(group);
+    }
+    return this;
+  }
+
   /// Enqueue a new [Task]
   ///
   /// Returns true if successfully enqueued. A new task will also generate
@@ -713,6 +740,10 @@ class FileDownloader {
         'Either task or filePath must be set, not both');
     return _downloader.openFile(task, filePath, mimeType);
   }
+
+  /// Closes the [updates] stream and re-initializes the [StreamController]
+  /// such that the stream can be listened to again
+  Future<void> resetUpdates() => _downloader.resetUpdatesStreamController();
 
   /// Destroy the [FileDownloader]. Subsequent use requires initialization
   void destroy() {

--- a/lib/src/models.dart
+++ b/lib/src/models.dart
@@ -598,8 +598,7 @@ class DownloadTask extends Task {
       if ([200, 201, 202, 203, 204, 205, 206].contains(response.statusCode)) {
         final disposition = response.headers.entries
             .firstWhere(
-              (element) => element.key.toLowerCase() == 'content-disposition',
-            )
+                (element) => element.key.toLowerCase() == 'content-disposition')
             .value;
         // Try filename="filename"
         final plainFilenameRegEx =

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: background_downloader
 description: A multi-platform background file downloader and uploader. Define the task, enqueue and monitor progress
 
-version: 6.0.0
+version: 6.1.0
 repository: https://github.com/781flyingdutchman/background_downloader
 
 environment:


### PR DESCRIPTION
Fix #46 and #48 

Added `unregisterCallBacks` to remove callbacks if you no longer want updates, and `resetUpdates` to reset the `updates` stream so it can be listened to again.

Bug fix for `DownloadTask.withSuggestedFilename` for servers that do not follow case convention for the Content-Disposition header.