### PR TITLE
Database path migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,18 @@
+## 7.0.1
+
+Migrating the persistent data from the documents directory to the support directory, so it is no longer visible in - for example - the iOS Files app, or the Linux home directory.
+
+Further Dart3 changes (not visible to user).
+
 ## 7.0.0
 
 Migration to Dart 3 - not other functional change or API change.  If you use Dart 2 please use version `6.1.1` of this plugin, which will be maintained until the end of 2023.
 
 Most classes in the package are now `final` classes, and under the hood we use the new Records and Pattern matching features of Dart 3. None of this should matter if you've used the package as intended.
+
+## 6.1.2
+
+Migrating the persistent data from the documents directory to the support directory, so it is no longer visible in - for example - the iOS Files app, or the Linux home directory.
 
 ## 6.1.1
 

--- a/LICENSE
+++ b/LICENSE
@@ -9,3 +9,29 @@ Redistribution and use in source and binary forms, with or without modification,
 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+---
+
+This software includes a modified version of package localstore (https://pub.dev/packages/localstore/versions/1.3.5). The license for that software is:
+
+MIT License
+
+Copyright (c) 2021 Hanoi University of Mining and Geology, Vietnam.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/example/integration_test/database_test.dart
+++ b/example/integration_test/database_test.dart
@@ -3,7 +3,6 @@ import 'dart:io';
 import 'package:background_downloader/background_downloader.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:localstore/localstore.dart';
 import 'package:path/path.dart' as path;
 import 'package:path_provider/path_provider.dart';
 
@@ -18,14 +17,33 @@ final record2 = TaskRecord(task2, TaskStatus.enqueued, 0);
 
 final db = Localstore.instance;
 
+Future<void> deleteAllTaskDataFromFileSystem() async {
+  final docDirTasksDir = path.join(
+      (await getApplicationDocumentsDirectory()).path, Database.tasksPath);
+  final supportDirTasksDir = path.join(
+      (await getApplicationSupportDirectory()).path, Database.tasksPath);
+  try {
+    await Directory(docDirTasksDir).delete(recursive: true);
+  } catch (e) {
+    debugPrint(e.toString());
+  }
+  try {
+    await Directory(supportDirTasksDir).delete(recursive: true);
+  } catch (e) {
+    debugPrint(e.toString());
+  }
+}
+
 void main() {
   setUp(() async {
     WidgetsFlutterBinding.ensureInitialized();
-    await Database().deleteAllRecords();
+    await deleteAllTaskDataFromFileSystem();
+    Localstore.instance.clearCache();
   });
 
   tearDown(() async {
-    await Database().deleteAllRecords();
+    await deleteAllTaskDataFromFileSystem();
+    Localstore.instance.clearCache();
   });
 
   testWidgets('updateRecord', (tester) async {
@@ -41,7 +59,7 @@ void main() {
     expect(records2?.values.length, equals(2));
     // confirm file exists in file system
     await Future.delayed(const Duration(milliseconds: 200));
-    final docDir = await getApplicationDocumentsDirectory();
+    final docDir = await getApplicationSupportDirectory();
     final filePath = '$tasksPath/${record.taskId}';
     expect(File(path.join(docDir.path, filePath)).existsSync(), isTrue);
   });

--- a/example/integration_test/migration_test.dart
+++ b/example/integration_test/migration_test.dart
@@ -1,0 +1,79 @@
+import 'dart:io';
+
+import 'package:background_downloader/background_downloader.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:logging/logging.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:path/path.dart' as path;
+
+const tasksPath = 'backgroundDownloaderTaskRecords';
+const databaseMetadataPath = 'backgroundDownloaderDatabase';
+
+void main() {
+  setUp(() async {
+    Logger.root.level = Level.ALL;
+    Logger.root.onRecord.listen((LogRecord rec) {
+      debugPrint(
+          '${rec.loggerName}>${rec.level.name}: ${rec.time}: ${rec.message}');
+    });
+    WidgetsFlutterBinding.ensureInitialized();
+    for (var dir in [
+      await getApplicationDocumentsDirectory(),
+      await getApplicationSupportDirectory()
+    ]) {
+      try {
+        Directory(path.join(dir.path, tasksPath)).deleteSync(recursive: true);
+      } catch (e) {
+        debugPrint('$dir tasksPath was already deleted');
+      }
+      try {
+        Directory(path.join(dir.path, databaseMetadataPath))
+            .deleteSync(recursive: true);
+      } catch (e) {
+        debugPrint('$dir databaseMetadataPath was already deleted');
+      }
+    }
+    Localstore.instance.clearCache();
+  });
+
+  tearDown(() async {});
+
+  testWidgets('migration from version 0', (widgetTester) async {
+    final docDir = await getApplicationDocumentsDirectory();
+    final supportDir = await getApplicationSupportDirectory();
+    Directory(path.join(docDir.path, tasksPath)).createSync();
+    await File(path.join(docDir.path, tasksPath, 'test'))
+        .writeAsString('contents', flush: true);
+    expect(
+        File(path.join(docDir.path, tasksPath, 'test')).existsSync(), isTrue);
+    final downloader = FileDownloader().downloaderForTesting;
+    await Future.delayed(const Duration(milliseconds: 100));
+    // file 'test' in docDir should have been moved to supportDir
+    expect(
+        File(path.join(docDir.path, tasksPath, 'test')).existsSync(), isFalse);
+    expect(File(path.join(supportDir.path, tasksPath, 'test')).existsSync(),
+        isTrue);
+    final metaData = await Localstore.instance
+        .collection('backgroundDownloaderDatabase')
+        .doc('metaData')
+        .get();
+    final version = metaData?['version'] ?? 0;
+    expect(version, equals(1)); // BaseDownloader.databaseVersion
+    // now initialize again
+    // docDir and supportDir file should not be touched
+    final file2 = File(path.join(docDir.path, tasksPath, 'test2'));
+    Directory(path.join(docDir.path, tasksPath)).createSync();
+    await file2.writeAsString('contents2');
+    expect(
+        File(path.join(docDir.path, tasksPath, 'test2')).existsSync(), isTrue);
+    await downloader.initialize();
+    expect(
+        File(path.join(docDir.path, tasksPath, 'test2')).existsSync(), isTrue);
+    expect(File(path.join(supportDir.path, tasksPath, 'test2')).existsSync(),
+        isFalse);
+    expect(File(path.join(supportDir.path, tasksPath, 'test')).existsSync(),
+        isTrue);
+    debugPrint('Migration done');
+  });
+}

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -39,7 +39,6 @@ dev_dependencies:
     sdk: flutter
   path: ^1.8.2
   path_provider: ^2.0.11
-  localstore: ^1.3.4
 
   # The "flutter_lints" package below contains a set of recommended lints to
   # encourage good coding practices. The lint set provided by the package is

--- a/lib/background_downloader.dart
+++ b/lib/background_downloader.dart
@@ -2,3 +2,4 @@ export 'src/file_downloader.dart' show FileDownloader;
 export 'src/models.dart';
 export 'src/exceptions.dart';
 export 'src/database.dart';
+export 'src/localstore/localstore.dart';

--- a/lib/src/base_downloader.dart
+++ b/lib/src/base_downloader.dart
@@ -112,11 +112,9 @@ abstract class BaseDownloader {
               log.fine('Error migrating database for path $path: $e');
             }
           }
-          break;
 
         default:
           log.warning('Illegal starting version: $version');
-          break;
       }
       await _db
           .collection(metaDataCollection)
@@ -635,30 +633,15 @@ abstract class BaseDownloader {
       }
       if (progress == null && status != null) {
         // set progress based on status
-        switch (status) {
-          case TaskStatus.enqueued:
-          case TaskStatus.running:
-            progress = 0.0;
-            break;
-          case TaskStatus.complete:
-            progress = progressComplete;
-            break;
-          case TaskStatus.notFound:
-            progress = progressNotFound;
-            break;
-          case TaskStatus.failed:
-            progress = progressFailed;
-            break;
-          case TaskStatus.canceled:
-            progress = progressCanceled;
-            break;
-          case TaskStatus.waitingToRetry:
-            progress = progressWaitingToRetry;
-            break;
-          case TaskStatus.paused:
-            progress = progressPaused;
-            break;
-        }
+        progress = switch (status) {
+          TaskStatus.enqueued || TaskStatus.running => 0.0,
+          TaskStatus.complete => progressComplete,
+          TaskStatus.notFound => progressNotFound,
+          TaskStatus.failed => progressFailed,
+          TaskStatus.canceled => progressCanceled,
+          TaskStatus.waitingToRetry => progressWaitingToRetry,
+          TaskStatus.paused => progressPaused
+        };
       }
       Database()
           .updateRecord(TaskRecord(task, status!, progress!, taskException));

--- a/lib/src/base_downloader.dart
+++ b/lib/src/base_downloader.dart
@@ -5,11 +5,14 @@ import 'dart:math';
 import 'package:flutter/foundation.dart';
 import 'package:logging/logging.dart';
 import 'package:collection/collection.dart';
-import 'package:localstore/localstore.dart';
+
+import 'package:path/path.dart';
+import 'package:path_provider/path_provider.dart';
 
 import 'database.dart';
 import 'desktop_downloader.dart';
 import 'exceptions.dart';
+import 'localstore/localstore.dart';
 import 'models.dart';
 import 'native_downloader.dart';
 
@@ -29,6 +32,9 @@ abstract class BaseDownloader {
   static const resumeDataPath = 'backgroundDownloaderResumeData';
   static const pausedTasksPath = 'backgroundDownloaderPausedTasks';
   static const modifiedTasksPath = 'backgroundDownloaderModifiedTasks';
+  static const metaDataCollection = 'backgroundDownloaderDatabase';
+
+  static const databaseVersion = 1;
 
   /// Persistent storage
   final _db = Localstore.instance;
@@ -67,7 +73,57 @@ abstract class BaseDownloader {
   }
 
   /// Initialize
-  Future<void> initialize();
+  ///
+  /// Initializes the Localstore instance and if necessary perform database
+  /// migration, then initializes the subclassed implementation for
+  /// desktop or native
+  @mustCallSuper
+  Future<void> initialize() async {
+    final metaData =
+        await _db.collection(metaDataCollection).doc('metaData').get();
+    final version = metaData?['version'] ?? 0;
+    if (version != databaseVersion) {
+      log.fine('Migrating database from version $version to $databaseVersion');
+      switch (version) {
+        case 0:
+          // move files from docDir to supportDir
+          final docDir = await getApplicationDocumentsDirectory();
+          final supportDir = await getApplicationSupportDirectory();
+          for (String path in [
+            resumeDataPath,
+            pausedTasksPath,
+            modifiedTasksPath,
+            Database.tasksPath
+          ]) {
+            try {
+              final fromPath = join(docDir.path, path);
+              if (await Directory(fromPath).exists()) {
+                log.finest('Moving $path to support directory');
+                final toPath = join(supportDir.path, path);
+                await Directory(toPath).create(recursive: true);
+                await Directory(fromPath).list().forEach((entity) {
+                  if (entity is File) {
+                    entity.copySync(join(toPath, basename(entity.path)));
+                  }
+                });
+                await Directory(fromPath).delete(recursive: true);
+              }
+            } catch (e) {
+              log.fine('Error migrating database for path $path: $e');
+            }
+          }
+          break;
+
+        default:
+          log.warning('Illegal starting version: $version');
+          break;
+      }
+      await _db
+          .collection(metaDataCollection)
+          .doc('metaData')
+          .set({'version': databaseVersion});
+    }
+  }
 
   /// Retrieve data that was stored locally because it could not be
   /// delivered to the downloader
@@ -306,7 +362,7 @@ abstract class BaseDownloader {
       await _db.collection(resumeDataPath).delete();
       return;
     }
-    await _db.collection(resumeDataPath).doc(taskId).delete();
+    await _db.collection(resumeDataPath).doc(_safeId(taskId)).delete();
   }
 
   /// Store the paused [task]
@@ -337,7 +393,7 @@ abstract class BaseDownloader {
       await _db.collection(pausedTasksPath).delete();
       return;
     }
-    await _db.collection(pausedTasksPath).doc(taskId).delete();
+    await _db.collection(pausedTasksPath).doc(_safeId(taskId)).delete();
   }
 
   /// Retrieve data that was not delivered to Dart

--- a/lib/src/database.dart
+++ b/lib/src/database.dart
@@ -1,7 +1,6 @@
-import 'package:localstore/localstore.dart';
-
 import 'base_downloader.dart';
 import 'exceptions.dart';
+import 'localstore/localstore.dart';
 import 'models.dart';
 
 /// Persistent database used for tracking task status and progress.

--- a/lib/src/desktop_downloader.dart
+++ b/lib/src/desktop_downloader.dart
@@ -39,9 +39,6 @@ class DesktopDownloader extends BaseDownloader {
   DesktopDownloader._internal();
 
   @override
-  Future<void> initialize() async {}
-
-  @override
   Future<bool> enqueue(Task task,
       [TaskNotificationConfig? notificationConfig]) async {
     try {

--- a/lib/src/file_downloader.dart
+++ b/lib/src/file_downloader.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:math';
 
+import 'package:background_downloader/background_downloader.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
@@ -755,6 +756,7 @@ final class FileDownloader {
     _taskProgressCallbacks.clear();
     _notificationConfigs.clear();
     _downloader.destroy();
+    Localstore.instance.clearCache();
   }
 }
 

--- a/lib/src/file_downloader.dart
+++ b/lib/src/file_downloader.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:math';
 
-import 'package:background_downloader/background_downloader.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
@@ -12,6 +11,7 @@ import 'base_downloader.dart';
 import 'database.dart';
 import 'desktop_downloader.dart';
 import 'exceptions.dart';
+import 'localstore/localstore.dart';
 import 'models.dart';
 
 /// Provides access to all functions of the plugin in a single place.

--- a/lib/src/localstore/collection_ref.dart
+++ b/lib/src/localstore/collection_ref.dart
@@ -1,0 +1,102 @@
+part of localstore;
+
+/// A [CollectionRef] object can be used for adding documents, getting
+/// [DocumentRef]s, and querying for documents.
+class CollectionRef implements CollectionRefImpl {
+  String _id;
+
+  /// A string representing the path of the referenced document (relative to the
+  /// root of the database).
+  String get path => _path;
+
+  String _path = '';
+
+  DocumentRef? _delegate;
+
+  CollectionRef? _parent;
+
+  List<List>? _conditions;
+
+  static final pathSeparatorRegEx = RegExp(r'[/\\]');
+
+  /// The parent [CollectionRef] of this document.
+  CollectionRef? get parent => _parent;
+
+  CollectionRef._(this._id, [this._parent, this._delegate, this._conditions]) {
+    _path = _buildPath(_parent?.path, _id, _delegate?.id);
+  }
+  static final _cache = <String, CollectionRef>{};
+
+  /// Returns an instance using the default [CollectionRef].
+  factory CollectionRef(
+    String id, [
+    CollectionRef? parent,
+    DocumentRef? delegate,
+    List<List>? conditions,
+  ]) {
+    final key = _buildPath(parent?.path, id, delegate?.id);
+    final collectionRef = _cache.putIfAbsent(
+        key, () => CollectionRef._(id, parent, delegate, conditions));
+    collectionRef._conditions = conditions;
+    return collectionRef;
+  }
+
+  static String _buildPath(String? parentPath, String path, String? docId) {
+    final docPath =
+        ((docId != null && parentPath != null) ? '$docId.collection' : '');
+    final pathSep = p.separator;
+    return '${parentPath ?? ''}$docPath$pathSep$path$pathSep';
+  }
+
+  final _utils = Utils.instance;
+
+  @override
+  Stream<Map<String, dynamic>> get stream => _utils.stream(path, _conditions);
+
+  @override
+  Future<Map<String, dynamic>?> get() async {
+    return await _utils.get(path, true, _conditions);
+  }
+
+  @override
+  DocumentRef doc([String? id]) {
+    id ??= int.parse(
+            '${Random().nextInt(1000000000)}${Random().nextInt(1000000000)}')
+        .toRadixString(35)
+        .substring(0, 9);
+    return DocumentRef(id, this);
+  }
+
+  @override
+  CollectionRef where(
+    field, {
+    isEqualTo,
+  }) {
+    final conditions = <List>[];
+    void addCondition(dynamic field, String operator, dynamic value) {
+      List<dynamic> condition;
+
+      condition = <dynamic>[field, operator, value];
+      conditions.add(condition);
+    }
+
+    if (isEqualTo != null) addCondition(field, '==', isEqualTo);
+
+    _conditions = conditions;
+
+    return this;
+  }
+
+  @override
+  Future<void> delete() async {
+    final docs = await _utils.get(path, true, _conditions);
+    if (docs != null) {
+      for (var key in docs.keys) {
+        final id = key.split(pathSeparatorRegEx).last;
+        DocumentRef(id, this)._data.clear();
+      }
+    }
+
+    await _utils.delete(path);
+  }
+}

--- a/lib/src/localstore/collection_ref_impl.dart
+++ b/lib/src/localstore/collection_ref_impl.dart
@@ -1,0 +1,32 @@
+part of localstore;
+
+/// The interface that other CollectionRef must extend.
+abstract class CollectionRefImpl {
+  /// Returns a `DocumentRef` with the provided id.
+  ///
+  /// If no [id] is provided, an auto-generated ID is used.
+  ///
+  /// The unique key generated is prefixed with a client-generated timestamp
+  /// so that the resulting list will be chronologically-sorted.
+  DocumentRef doc([String? id]);
+
+  /// Notifies of query results at this collection.
+  Stream<Map<String, dynamic>> get stream;
+
+  /// Fetch the documents for this collection
+  Future<Map<String, dynamic>?> get();
+
+  /// Creates and returns a new [CollectionRef] with additional filter on
+  /// specified [field]. [field] refers to a field in a document.
+  ///
+  /// `where` is not implemented
+  CollectionRef where(
+    field, {
+    isEqualTo,
+  });
+
+  /// Delete collection
+  ///
+  /// All collections and documents in this collection will be deleted.
+  Future<void> delete();
+}

--- a/lib/src/localstore/document_ref.dart
+++ b/lib/src/localstore/document_ref.dart
@@ -1,0 +1,71 @@
+part of localstore;
+
+/// A [DocumentRef] refers to a document location in a [Localstore] database
+/// and can be used to write, read, or listen to the location.
+///
+/// The document at the referenced location may or may not exist.
+/// A [DocumentRef] can also be used to create a [CollectionRef]
+/// to a subcollection.
+class DocumentRef implements DocumentRefImpl {
+  String _id;
+
+  /// This document's given ID within the collection.
+  String get id => _id;
+
+  CollectionRef? _delegate;
+
+  DocumentRef._(this._id, [this._delegate]);
+
+  static final _cache = <String, DocumentRef>{};
+
+  /// Returns an instance using the default [DocumentRef].
+  factory DocumentRef(String id, [CollectionRef? delegate]) {
+    final key = '${delegate?.path ?? ''}$id';
+    return _cache.putIfAbsent(key, () => DocumentRef._(id, delegate));
+  }
+
+  /// A string representing the path of the referenced document (relative to the
+  /// root of the database).
+  String get path => '${_delegate?.path}$id';
+
+  final _utils = Utils.instance;
+
+  final Map<String, dynamic> _data = {};
+
+  @override
+  Future<dynamic> set(Map<String, dynamic> data, [SetOptions? options]) async {
+    options ??= SetOptions();
+    if (options.merge) {
+      final output = Map<String, dynamic>.from(data);
+      Map<String, dynamic>? input = _data[id] ?? {};
+      output.updateAll((key, value) {
+        input![key] = value;
+      });
+      _data[id] = input;
+    } else {
+      _data[id] = data;
+    }
+    _utils.set(_data[id], path);
+  }
+
+  @override
+  Future<Map<String, dynamic>?> get() async {
+    return _data[id] ?? await _utils.get(path);
+  }
+
+  @override
+  Future delete() async {
+    await _utils.delete(path);
+    _data.remove(id);
+  }
+
+  @override
+  CollectionRef collection(String id) {
+    return CollectionRef(id, _delegate, this);
+  }
+
+  @override
+  String toString() {
+    return _utils.toString();
+  }
+}

--- a/lib/src/localstore/document_ref_impl.dart
+++ b/lib/src/localstore/document_ref_impl.dart
@@ -1,0 +1,20 @@
+part of localstore;
+
+/// The interface that other DocumentRef must extend.
+abstract class DocumentRefImpl {
+  /// Gets a [CollectionRef] for the specified Localstore path.
+  CollectionRef collection(String path);
+
+  /// Sets data on the document, overwriting any existing data. If the document
+  /// does not yet exist, it will be created.
+  ///
+  /// If [SetOptions] are provided, the data will be merged into an existing
+  /// document instead of overwriting.
+  Future<dynamic> set(Map<String, dynamic> data, [SetOptions? options]);
+
+  /// Reads the document referenced by this [DocumentRef].
+  Future<Map<String, dynamic>?> get();
+
+  /// Deletes the current document from the collection.
+  Future delete();
+}

--- a/lib/src/localstore/localstore.dart
+++ b/lib/src/localstore/localstore.dart
@@ -1,0 +1,18 @@
+library localstore;
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+import 'dart:math';
+
+import 'utils/html.dart' if (dart.library.io) 'utils/io.dart';
+
+part 'collection_ref.dart';
+part 'collection_ref_impl.dart';
+part 'document_ref.dart';
+part 'document_ref_impl.dart';
+part 'set_option.dart';
+part 'localstore_base.dart';
+part 'localstore_impl.dart';

--- a/lib/src/localstore/localstore_base.dart
+++ b/lib/src/localstore/localstore_base.dart
@@ -1,0 +1,32 @@
+part of localstore;
+
+/// The entry point for accessing a [Localstore].
+///
+/// You can get an instance by calling [Localstore.instance], for example:
+///
+/// ```dart
+/// final db = Localstore.instance;
+/// ```
+class Localstore implements LocalstoreImpl {
+  final _databaseDirectory = getApplicationSupportDirectory();
+  final _delegate = DocumentRef._('');
+  static final Localstore _localstore = Localstore._();
+
+  /// Private initializer
+  Localstore._();
+
+  /// Returns an instance using the default [Localstore].
+  static Localstore get instance => _localstore;
+
+  Future<Directory> get databaseDirectory => _databaseDirectory;
+
+  /// Clears the cache - needed only if filesystem has been manipulated directly
+  void clearCache() {
+    Utils.instance.clearCache();
+  }
+
+  @override
+  CollectionRef collection(String path) {
+    return CollectionRef(path, null, _delegate);
+  }
+}

--- a/lib/src/localstore/localstore_impl.dart
+++ b/lib/src/localstore/localstore_impl.dart
@@ -1,0 +1,7 @@
+part of localstore;
+
+/// The interface that other Localstore must extend.
+abstract class LocalstoreImpl {
+  /// Gets a [CollectionRef] for the specified Localstore path.
+  CollectionRef collection(String path);
+}

--- a/lib/src/localstore/set_option.dart
+++ b/lib/src/localstore/set_option.dart
@@ -1,0 +1,14 @@
+part of localstore;
+
+/// An options class that configures the behavior of set() calls in
+/// [DocumentRef].
+class SetOptions {
+  final bool _merge;
+
+  /// Changes the behavior of a set() call to only replace the values specified
+  /// in its data argument.
+  bool get merge => _merge;
+
+  /// Creates a [SetOptions] instance.
+  SetOptions({bool merge = false}) : _merge = merge;
+}

--- a/lib/src/localstore/utils/html.dart
+++ b/lib/src/localstore/utils/html.dart
@@ -1,0 +1,223 @@
+import 'dart:async';
+import 'dart:convert';
+// ignore: avoid_web_libraries_in_flutter
+import 'dart:html' as html;
+
+import 'utils_impl.dart';
+
+/// Utils class
+class Utils implements UtilsImpl {
+  Utils._();
+  static final Utils _utils = Utils._();
+  static Utils get instance => _utils;
+
+  @override
+  void clearCache() {
+    // no cache on web
+  }
+
+  @override
+  Future<Map<String, dynamic>?> get(String path,
+      [bool? isCollection = false, List<List>? conditions]) async {
+    // Fetch the documents for this collection
+    if (isCollection != null && isCollection == true) {
+      var dataCol = html.window.localStorage.entries.singleWhere(
+        (e) => e.key == path,
+        orElse: () => const MapEntry('', ''),
+      );
+      if (dataCol.key != '') {
+        if (conditions != null && conditions.first.isNotEmpty) {
+          return _getAll(dataCol);
+          /*
+          final ck = conditions.first[0] as String;
+          final co = conditions.first[1];
+          final cv = conditions.first[2];
+          // With conditions
+          try {
+            final mapCol = json.decode(dataCol.value) as Map<String, dynamic>;
+            final its = SplayTreeMap.of(mapCol);
+            its.removeWhere((key, value) {
+              if (value is Map<String, dynamic>) {
+                final key = value.keys.contains(ck);
+                final check = value[ck] as bool;
+                return !(key == true && check == cv);
+              }
+              return false;
+            });
+            its.forEach((key, value) {
+              final data = value as Map<String, dynamic>;
+              _data[key] = data;
+            });
+            return _data;
+          } catch (error) {
+            throw error;
+          }
+          */
+        } else {
+          return _getAll(dataCol);
+        }
+      }
+    } else {
+      final data = await _readFromStorage(path);
+      final id = path.substring(path.lastIndexOf('/') + 1, path.length);
+      if (data is Map<String, dynamic>) {
+        if (data.containsKey(id)) return data[id];
+        return null;
+      }
+    }
+    return null;
+  }
+
+  @override
+  Future<dynamic>? set(Map<String, dynamic> data, String path) {
+    return _writeToStorage(data, path);
+  }
+
+  @override
+  Future delete(String path) async {
+    _deleteFromStorage(path);
+  }
+
+  @override
+  Stream<Map<String, dynamic>> stream(String path, [List<List>? conditions]) {
+    // ignore: close_sinks
+    final storage = _storageCache[path] ??
+        _storageCache.putIfAbsent(
+            path, () => StreamController<Map<String, dynamic>>.broadcast());
+
+    _initStream(storage, path);
+    return storage.stream;
+  }
+
+  Map<String, dynamic>? _getAll(MapEntry<String, String> dataCol) {
+    final items = <String, dynamic>{};
+    try {
+      final mapCol = json.decode(dataCol.value) as Map<String, dynamic>;
+      mapCol.forEach((key, value) {
+        final data = value as Map<String, dynamic>;
+        items[key] = data;
+      });
+      if (items.isEmpty) return null;
+      return items;
+    } catch (error) {
+      rethrow;
+    }
+  }
+
+  void _initStream(
+      StreamController<Map<String, dynamic>> storage, String path) {
+    var dataCol = html.window.localStorage.entries.singleWhere(
+      (e) => e.key == path,
+      orElse: () => const MapEntry('', ''),
+    );
+    try {
+      if (dataCol.key != '') {
+        final mapCol = json.decode(dataCol.value) as Map<String, dynamic>;
+        mapCol.forEach((key, value) {
+          final data = value as Map<String, dynamic>;
+          storage.add(data);
+        });
+      }
+    } catch (error) {
+      rethrow;
+    }
+  }
+
+  final _storageCache = <String, StreamController<Map<String, dynamic>>>{};
+
+  Future<dynamic> _readFromStorage(String path) async {
+    final key = path.replaceAll(RegExp(r'[^\/]+\/?$'), '');
+    final data = html.window.localStorage.entries.firstWhere(
+      (i) => i.key == key,
+      orElse: () => const MapEntry('', ''),
+    );
+    if (data != const MapEntry('', '')) {
+      try {
+        return json.decode(data.value) as Map<String, dynamic>;
+      } catch (e) {
+        return e;
+      }
+    }
+  }
+
+  Future<dynamic> _writeToStorage(
+    Map<String, dynamic> data,
+    String path,
+  ) async {
+    final key = path.replaceAll(RegExp(r'[^\/]+\/?$'), '');
+
+    final uri = Uri.parse(path);
+    final id = uri.pathSegments.last;
+    var dataCol = html.window.localStorage.entries.singleWhere(
+      (e) => e.key == key,
+      orElse: () => const MapEntry('', ''),
+    );
+    try {
+      if (dataCol.key != '') {
+        final mapCol = json.decode(dataCol.value) as Map<String, dynamic>;
+        mapCol[id] = data;
+        dataCol = MapEntry(id, json.encode(mapCol));
+        html.window.localStorage.update(
+          key,
+          (value) => dataCol.value,
+          ifAbsent: () => dataCol.value,
+        );
+      } else {
+        html.window.localStorage.update(
+          key,
+          (value) => json.encode({id: data}),
+          ifAbsent: () => json.encode({id: data}),
+        );
+      }
+      // ignore: close_sinks
+      final storage = _storageCache[key] ??
+          _storageCache.putIfAbsent(
+              key, () => StreamController<Map<String, dynamic>>.broadcast());
+
+      storage.sink.add(data);
+    } catch (error) {
+      rethrow;
+    }
+  }
+
+  Future<dynamic> _deleteFromStorage(String path) async {
+    if (path.endsWith('/')) {
+      // If path is a directory path
+      final dataCol = html.window.localStorage.entries.singleWhere(
+        (element) => element.key == path,
+        orElse: () => const MapEntry('', ''),
+      );
+
+      try {
+        if (dataCol.key != '') {
+          html.window.localStorage.remove(dataCol.key);
+        }
+      } catch (error) {
+        rethrow;
+      }
+    } else {
+      // If path is a file path
+      final uri = Uri.parse(path);
+      final key = path.replaceAll(RegExp(r'[^\/]+\/?$'), '');
+      final id = uri.pathSegments.last;
+      var dataCol = html.window.localStorage.entries.singleWhere(
+        (e) => e.key == key,
+        orElse: () => const MapEntry('', ''),
+      );
+
+      try {
+        if (dataCol.key != '') {
+          final mapCol = json.decode(dataCol.value) as Map<String, dynamic>;
+          mapCol.remove(id);
+          html.window.localStorage.update(
+            key,
+            (value) => json.encode(mapCol),
+            ifAbsent: () => dataCol.value,
+          );
+        }
+      } catch (error) {
+        rethrow;
+      }
+    }
+  }
+}

--- a/lib/src/localstore/utils/io.dart
+++ b/lib/src/localstore/utils/io.dart
@@ -5,6 +5,9 @@ import 'dart:typed_data';
 
 import '../localstore.dart';
 import 'utils_impl.dart';
+import 'package:logging/logging.dart';
+
+final _log = Logger('Localstore');
 
 class Utils implements UtilsImpl {
   Utils._();
@@ -202,7 +205,7 @@ class Utils implements UtilsImpl {
     try {
       await file.delete();
     } catch (e) {
-      print(e);
+      _log.finest(e);
     }
     _fileCache.remove(path);
   }
@@ -213,7 +216,7 @@ class Utils implements UtilsImpl {
     try {
       await dir.delete(recursive: true);
     } catch (e) {
-      print(e);
+      _log.finest(e);
     }
     _fileCache.removeWhere((key, value) => key.startsWith(path));
   }

--- a/lib/src/localstore/utils/io.dart
+++ b/lib/src/localstore/utils/io.dart
@@ -1,0 +1,220 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import '../localstore.dart';
+import 'utils_impl.dart';
+
+class Utils implements UtilsImpl {
+  Utils._();
+
+  static final Utils _utils = Utils._();
+  static final lastPathComponentRegEx = RegExp(r'[^/\\]+[/\\]?$');
+
+  static Utils get instance => _utils;
+  final _storageCache = <String, StreamController<Map<String, dynamic>>>{};
+  final _fileCache = <String, File>{};
+
+  /// Clears the cache
+  @override
+  void clearCache() {
+    _storageCache.clear();
+    _fileCache.clear();
+  }
+
+  @override
+  Future<Map<String, dynamic>?> get(String path,
+      [bool? isCollection = false, List<List>? conditions]) async {
+    // Fetch the documents for this collection
+    if (isCollection != null && isCollection == true) {
+      final dbDir = await Localstore.instance.databaseDirectory;
+      final fullPath = '${dbDir.path}$path';
+      final dir = Directory(fullPath);
+      if (!dir.existsSync()) {
+        dir.createSync(recursive: true);
+      }
+      List<FileSystemEntity> entries =
+          dir.listSync(recursive: false).whereType<File>().toList();
+      if (conditions != null && conditions.first.isNotEmpty) {
+        return await _getAll(entries);
+        /*
+        // With conditions
+        entries.forEach((e) async {
+          final path = e.path.replaceAll(_docDir!.absolute.path, '');
+          final file = await _getFile(path);
+          _readFile(file!).then((data) {
+            if (data is Map<String, dynamic>) {
+              _data[path] = data;
+            }
+          });
+        });
+        return _data;
+        */
+      } else {
+        return await _getAll(entries);
+      }
+    } else {
+      // Reads the document referenced by this [DocumentRef].
+      final file = await _getFile(path);
+      final randomAccessFile = file!.openSync(mode: FileMode.append);
+      final data = await _readFile(randomAccessFile);
+      randomAccessFile.closeSync();
+      if (data is Map<String, dynamic>) {
+        final key = path.replaceAll(lastPathComponentRegEx, '');
+        // ignore: close_sinks
+        final storage = _storageCache.putIfAbsent(key, () => _newStream(key));
+        storage.add(data);
+        return data;
+      }
+    }
+    return null;
+  }
+
+  @override
+  Future<dynamic>? set(Map<String, dynamic> data, String path) {
+    return _writeFile(data, path);
+  }
+
+  @override
+  Future delete(String path) async {
+    if (path.endsWith(Platform.pathSeparator)) {
+      await _deleteDirectory(path);
+    } else {
+      await _deleteFile(path);
+    }
+  }
+
+  @override
+  Stream<Map<String, dynamic>> stream(String path, [List<List>? conditions]) {
+    // ignore: close_sinks
+    var storage = _storageCache[path];
+    if (storage == null) {
+      storage = _storageCache.putIfAbsent(path, () => _newStream(path));
+    } else {
+      _initStream(storage, path);
+    }
+    return storage.stream;
+  }
+
+  Future<Map<String, dynamic>?> _getAll(List<FileSystemEntity> entries) async {
+    final items = <String, dynamic>{};
+    final dbDir = await Localstore.instance.databaseDirectory;
+    await Future.forEach(entries, (FileSystemEntity e) async {
+      final path = e.path.replaceAll(dbDir.path, '');
+      final file = await _getFile(path);
+      final randomAccessFile = await file!.open(mode: FileMode.append);
+      final data = await _readFile(randomAccessFile);
+      await randomAccessFile.close();
+
+      if (data is Map<String, dynamic>) {
+        items[path] = data;
+      }
+    });
+
+    if (items.isEmpty) return null;
+    return items;
+  }
+
+  /// Streams all file in the path
+  StreamController<Map<String, dynamic>> _newStream(String path) {
+    final storage = StreamController<Map<String, dynamic>>.broadcast();
+    _initStream(storage, path);
+
+    return storage;
+  }
+
+  Future _initStream(
+    StreamController<Map<String, dynamic>> storage,
+    String path,
+  ) async {
+    final dbDir = await Localstore.instance.databaseDirectory;
+    final fullPath = '${dbDir.path}$path';
+    final dir = Directory(fullPath);
+    try {
+      List<FileSystemEntity> entries =
+          dir.listSync(recursive: false).whereType<File>().toList();
+      for (var e in entries) {
+        final path = e.path.replaceAll(dbDir.path, '');
+        final file = await _getFile(path);
+        final randomAccessFile = file!.openSync(mode: FileMode.append);
+        _readFile(randomAccessFile).then((data) {
+          randomAccessFile.closeSync();
+          if (data is Map<String, dynamic>) {
+            storage.add(data);
+          }
+        });
+      }
+    } catch (e) {
+      return e;
+    }
+  }
+
+  Future<dynamic> _readFile(RandomAccessFile file) async {
+    final length = file.lengthSync();
+    file.setPositionSync(0);
+    final buffer = Uint8List(length);
+    file.readIntoSync(buffer);
+    try {
+      final contentText = utf8.decode(buffer);
+      final data = json.decode(contentText) as Map<String, dynamic>;
+      return data;
+    } catch (e) {
+      return e;
+    }
+  }
+
+  Future<File?> _getFile(String path) async {
+    if (_fileCache.containsKey(path)) return _fileCache[path];
+
+    final dbDir = await Localstore.instance.databaseDirectory;
+
+    final file = File('${dbDir.path}$path');
+
+    if (!file.existsSync()) file.createSync(recursive: true);
+    _fileCache.putIfAbsent(path, () => file);
+
+    return file;
+  }
+
+  Future _writeFile(Map<String, dynamic> data, String path) async {
+    final serialized = json.encode(data);
+    final buffer = utf8.encode(serialized);
+    final file = await _getFile(path);
+    final randomAccessFile = file!.openSync(mode: FileMode.append);
+
+    randomAccessFile.lockSync();
+    randomAccessFile.setPositionSync(0);
+    randomAccessFile.writeFromSync(buffer);
+    randomAccessFile.truncateSync(buffer.length);
+    randomAccessFile.unlockSync();
+    randomAccessFile.closeSync();
+
+    final key = path.replaceAll(lastPathComponentRegEx, '');
+    // ignore: close_sinks
+    final storage = _storageCache.putIfAbsent(key, () => _newStream(key));
+    storage.add(data);
+  }
+
+  Future _deleteFile(String path) async {
+    final dbDir = await Localstore.instance.databaseDirectory;
+    final file = File('${dbDir.path}$path');
+    try {
+      await file.delete();
+    } catch (e) {
+      print(e);
+    }
+    _fileCache.remove(path);
+  }
+
+  Future _deleteDirectory(String path) async {
+    final dbDir = await Localstore.instance.databaseDirectory;
+    final dir = Directory('${dbDir.path}$path');
+    try {
+      await dir.delete(recursive: true);
+    } catch (e) {
+      print(e);
+    }
+    _fileCache.removeWhere((key, value) => key.startsWith(path));
+  }
+}

--- a/lib/src/localstore/utils/utils_impl.dart
+++ b/lib/src/localstore/utils/utils_impl.dart
@@ -1,0 +1,8 @@
+abstract class UtilsImpl {
+  void clearCache();
+  Future<Map<String, dynamic>?> get(String path,
+      [bool? isCollection = false, List<List>? conditions]);
+  Future<dynamic>? set(Map<String, dynamic> data, String path);
+  Future delete(String path);
+  Stream<Map<String, dynamic>> stream(String path, [List<List>? conditions]);
+}

--- a/lib/src/models.dart
+++ b/lib/src/models.dart
@@ -363,23 +363,16 @@ sealed class Task extends Request {
 
   /// Returns the absolute path to the file represented by this task
   Future<String> filePath() async {
-    final Directory baseDir;
-    switch (baseDirectory) {
-      case BaseDirectory.applicationDocuments:
-        baseDir = await getApplicationDocumentsDirectory();
-        break;
-      case BaseDirectory.temporary:
-        baseDir = await getTemporaryDirectory();
-        break;
-      case BaseDirectory.applicationSupport:
-        baseDir = await getApplicationSupportDirectory();
-        break;
-      case BaseDirectory.applicationLibrary:
-        baseDir = Platform.isMacOS || Platform.isIOS
-            ? await getLibraryDirectory()
-            : Directory(path.join(
-                (await getApplicationSupportDirectory()).path, 'Library'));
-    }
+    final Directory baseDir = await switch (baseDirectory) {
+      BaseDirectory.applicationDocuments => getApplicationDocumentsDirectory(),
+      BaseDirectory.temporary => getTemporaryDirectory(),
+      BaseDirectory.applicationSupport => getApplicationSupportDirectory(),
+      BaseDirectory.applicationLibrary
+          when Platform.isMacOS || Platform.isIOS =>
+        getLibraryDirectory(),
+      BaseDirectory.applicationLibrary => Future.value(Directory(
+          path.join((await getApplicationSupportDirectory()).path, 'Library')))
+    };
     return path.join(baseDir.path, directory, filename);
   }
 

--- a/lib/src/native_downloader.dart
+++ b/lib/src/native_downloader.dart
@@ -167,18 +167,11 @@ class NativeDownloader extends BaseDownloader {
   /// ProgressUpdates has a mixed Task & double json representation 'progress'
   @override
   Future<Map<String, dynamic>> popUndeliveredData(Undelivered dataType) async {
-    final String jsonMapString;
-    switch (dataType) {
-      case Undelivered.resumeData:
-        jsonMapString = await _channel.invokeMethod('popResumeData');
-        break;
-      case Undelivered.statusUpdates:
-        jsonMapString = await _channel.invokeMethod('popStatusUpdates');
-        break;
-      case Undelivered.progressUpdates:
-        jsonMapString = await _channel.invokeMethod('popProgressUpdates');
-        break;
-    }
+    final String jsonMapString = await switch (dataType) {
+      Undelivered.resumeData => _channel.invokeMethod('popResumeData'),
+      Undelivered.statusUpdates => _channel.invokeMethod('popStatusUpdates'),
+      Undelivered.progressUpdates => _channel.invokeMethod('popProgressUpdates')
+    };
     return jsonDecode(jsonMapString);
   }
 

--- a/lib/src/native_downloader.dart
+++ b/lib/src/native_downloader.dart
@@ -26,6 +26,7 @@ class NativeDownloader extends BaseDownloader {
 
   @override
   Future<void> initialize() async {
+    await super.initialize();
     WidgetsFlutterBinding.ensureInitialized();
     // listen to the background channel, receiving updates on download status
     // or progress.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: background_downloader
 description: A multi-platform background file downloader and uploader. Define the task, enqueue and monitor progress
 
-version: 7.0.0
+version: 7.0.1
 repository: https://github.com/781flyingdutchman/background_downloader
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,6 @@ dependencies:
   path: ^1.8.1
   async: ^2.6.0
   mime: ^1.0.1
-  localstore: ^1.3.5
   collection: ^1.15.0
 
 dev_dependencies:


### PR DESCRIPTION
Migrating the persistent data from the documents directory to the support directory, so it is no longer visible in - for example - the iOS Files app, or the Linux home directory.

