### PR TITLE
Fix permission checking for android 10

### DIFF
--- a/android/src/main/kotlin/com/bbflight/background_downloader/BackgroundDownloaderPlugin.kt
+++ b/android/src/main/kotlin/com/bbflight/background_downloader/BackgroundDownloaderPlugin.kt
@@ -479,7 +479,7 @@ class BackgroundDownloaderPlugin : FlutterPlugin, MethodCallHandler, ActivityAwa
         val directory = args[2] as String
         val mimeType = args[3] as String?
         // first check and potentially ask for permissions
-        if (Build.VERSION.SDK_INT < 30 && ActivityCompat.checkSelfPermission(
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q && ActivityCompat.checkSelfPermission(
                 applicationContext, Manifest.permission.WRITE_EXTERNAL_STORAGE
             ) != PackageManager.PERMISSION_GRANTED
         ) {


### PR DESCRIPTION
In https://github.com/781flyingdutchman/background_downloader/blob/76f2efe228ee2fd9ac9eb539e19ca8d858b86f75/android/src/main/kotlin/com/bbflight/background_downloader/SharedStorage.kt#L37 permission is checked as `Build.VERSION.SDK_INT < Build.VERSION_CODES.Q` which is `29`, but in the plugin it was compared to `30`. So on Android 10 (api 29) the `moveToSharedStorage` method hangs forever because those permissions are not available by default (only if https://developer.android.com/reference/android/R.attr#requestLegacyExternalStorage is true, which is false by default).

Sadly after the file is moved it cannot be opened by `openFile` on Android 10 and I couldn't find out why. I tried on android 9, 11 and 13 and the moved file opens, but 10 opens the external app (tried with like 3 pdf readers) which reports corrupted or not accessible file. So only the downloading part is fixed by this PR.