### PR TITLE
[android] TaskException is always overriden to general on error

### DIFF
--- a/android/src/main/kotlin/com/bbflight/background_downloader/TaskWorker.kt
+++ b/android/src/main/kotlin/com/bbflight/background_downloader/TaskWorker.kt
@@ -639,7 +639,6 @@ class TaskWorker(
                 }
 
                 else -> {
-                    taskException = TaskException(ExceptionType.general)
                     deleteTempFile(tempFilePath)
                     return TaskStatus.failed
                 }


### PR DESCRIPTION
If I switch Airplane mode on while downloading, then I get a `general` error instead of `connection`. It is not neccessary to fallback to `general` error without description in the modified else branch, as the status update function does it already (when `TaskException` is null). This assignment can override the previously set error, which exactly what happens in this airplane mode use-case.