### PR TITLE
[iOS] send images and videos to Photos with moveToSharedStorage

### DIFF
--- a/ios/Classes/Downloader.swift
+++ b/ios/Classes/Downloader.swift
@@ -384,7 +384,12 @@ public class Downloader: NSObject, FlutterPlugin, URLSessionDelegate, URLSession
             result(nil)
             return
         }
-        result(moveToSharedStorage(filePath: filePath, destination: destination, directory: directory))
+        moveToSharedStorage(
+            filePath: filePath,
+            destination: destination,
+            directory: directory,
+            complete: { (_ path: String?) in result(path) }
+        )
     }
 
     /// Returns path to file in a SharedStorage destination, or null

--- a/ios/Classes/SharedStorage.swift
+++ b/ios/Classes/SharedStorage.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import os.log
+import Photos
 
 public enum SharedStorage: Int {
     case downloads,
@@ -18,38 +19,84 @@ public enum SharedStorage: Int {
 }
 
 /// Move file at [filePath] to shared storage [destination] with optional [directory]
-public func moveToSharedStorage(filePath: String, destination: SharedStorage, directory: String) -> String? {
-    guard FileManager().fileExists(atPath: filePath)
-    else {
-        os_log("Cannot move to shared storage: file %@ does not exist", log: log, type: .error, filePath)
-        return nil
+public func moveToSharedStorage(filePath: String, destination: SharedStorage, directory: String, complete: @escaping (String?) -> Void) {
+    switch destination {
+    case .images:
+        saveImageToPhotos(filePath: filePath, complete: complete)
+    case .video:
+        saveVideoToPhotos(filePath: filePath, complete: complete)
+    default:
+        complete(moveToFakeSharedStorage(filePath: filePath, destination: destination, directory: directory))
     }
-    let fileUrl = NSURL(fileURLWithPath: filePath)
-    guard let directory = try? directoryForSharedStorage(destination: destination, directory: directory) else {
-        os_log("Cannot move to shared storage: no permission for directory %@", log: log, type: .error, directory)
-        return nil
-    }
-    if !FileManager.default.fileExists(atPath: directory.path) {
-        do
-        {
-            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories:  true)
-        } catch {
-            os_log("Cannot move to shared storage: failed to create directory %@: %@", log: log, type: .error, directory.path, error.localizedDescription)
-            return nil
+}
+
+private func saveImageToPhotos(filePath: String, complete: @escaping (String?) -> Void) {
+    var localId: String?
+
+    PHPhotoLibrary.shared().performChanges({
+        guard let fileURL: URL = URL(string: filePath) else {
+            complete(nil)
+            return
         }
+
+        let assetChangeRequest = PHAssetChangeRequest.creationRequestForAssetFromImage(atFileURL: fileURL)
+        localId = assetChangeRequest?.placeholderForCreatedAsset?.localIdentifier
+    }) { saved, _ in
+        guard saved, let unwrappedId = localId else {
+            complete(nil)
+            return
+        }
+
+        let assetResult: PHFetchResult = PHAsset.fetchAssets(withLocalIdentifiers: [unwrappedId], options: nil)
+
+        guard let asset = assetResult.firstObject else {
+            complete(nil)
+            return
+        }
+
+        asset.requestContentEditingInput(with: nil, completionHandler: { input, _ in
+            complete(input?.fullSizeImageURL?.path)
+        })
     }
-    let destUrl = directory.appendingPathComponent((filePath as NSString).lastPathComponent, isDirectory: false)
-    if FileManager.default.fileExists(atPath: destUrl.path) {
-        try? FileManager.default.removeItem(at: destUrl)
+}
+
+private func saveVideoToPhotos(filePath: String, complete: @escaping (String?) -> Void) {
+    var localId: String?
+
+    PHPhotoLibrary.shared().performChanges({
+        guard let fileURL: URL = URL(string: filePath) else {
+            os_log("not a valid URL %@", log: log, type: .error, filePath)
+            complete(nil)
+            return
+        }
+
+        let assetChangeRequest = PHAssetChangeRequest.creationRequestForAssetFromVideo(atFileURL: fileURL)
+        localId = assetChangeRequest?.placeholderForCreatedAsset?.localIdentifier
+    }) { (saved, error: Error?) in
+        guard saved, let unwrappedId = localId else {
+            if let unwrappedError = error {
+                os_log("not saved %@", log: log, type: .info, String(describing: unwrappedError))
+            }
+            complete(nil)
+            return
+        }
+
+        let assetResult: PHFetchResult = PHAsset.fetchAssets(withLocalIdentifiers: [unwrappedId], options: nil)
+
+        guard let asset = assetResult.firstObject else {
+            os_log("no assets found", log: log, type: .info)
+            complete(nil)
+            return
+        }
+
+        asset.requestContentEditingInput(with: nil, completionHandler: { input, _ in
+            if let urlAsset = input?.audiovisualAsset as? AVURLAsset {
+                complete(urlAsset.url.path)
+            } else {
+                complete(nil)
+            }
+        })
     }
-    do {
-        try FileManager.default.moveItem(at: fileUrl as URL, to: destUrl)
-    } catch {
-        os_log("Failed to move file %@ to %@: %@", log: log, type: .error, filePath, destUrl.path, error.localizedDescription)
-        return nil
-    }
-    os_log("Moved from %@ to %@", log: log, type: .info, fileUrl, destUrl.path)
-    return destUrl.path
 }
 
 /// Returns the path to the file at [filePath] in shared storage [destination] subdir [directory], or null
@@ -88,4 +135,37 @@ public func directoryForSharedStorage(destination: SharedStorage, directory: Str
     return directory.isEmpty
         ? documentsURL?.appendingPathComponent(dir)
         : documentsURL?.appendingPathComponent(dir).appendingPathComponent(directory)
+}
+
+private func moveToFakeSharedStorage(filePath: String, destination: SharedStorage, directory: String) -> String? {
+    guard FileManager().fileExists(atPath: filePath)
+    else {
+        os_log("Cannot move to shared storage: file %@ does not exist", log: log, type: .error, filePath)
+        return nil
+    }
+    let fileUrl = NSURL(fileURLWithPath: filePath)
+    guard let directory = try? directoryForSharedStorage(destination: destination, directory: directory) else {
+        os_log("Cannot move to shared storage: no permission for directory %@", log: log, type: .error, directory)
+        return nil
+    }
+    if !FileManager.default.fileExists(atPath: directory.path) {
+        do {
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        } catch {
+            os_log("Cannot move to shared storage: failed to create directory %@: %@", log: log, type: .error, directory.path, error.localizedDescription)
+            return nil
+        }
+    }
+    let destUrl = directory.appendingPathComponent((filePath as NSString).lastPathComponent, isDirectory: false)
+    if FileManager.default.fileExists(atPath: destUrl.path) {
+        try? FileManager.default.removeItem(at: destUrl)
+    }
+    do {
+        try FileManager.default.moveItem(at: fileUrl as URL, to: destUrl)
+    } catch {
+        os_log("Failed to move file %@ to %@: %@", log: log, type: .error, filePath, destUrl.path, error.localizedDescription)
+        return nil
+    }
+    os_log("Moved from %@ to %@", log: log, type: .info, fileUrl, destUrl.path)
+    return destUrl.path
 }


### PR DESCRIPTION
TL;DR; Needed this for myself, so thought I'd share

## Background
On iOS, when a user downloads an image or video, they generally expect it to show up in their camera roll.  Since this package already exposes a `SharedStorage` enum, including `.images` and `.video`, I implemented this on the iOS side.

## This Breaks Things
This implementation breaks `pathInSharedStorage`, which is designed to take the initial filename, and extrapolate the shared path/filename.  Since iOS creates a new filename for images/videos moved to Photos, this method cannot be implemented AFAIK.

But:
1. I didn't realize this broke `pathInSharedStorage` until after I had implemented this PR
2. I couldn't actually figure out a use case for `pathInSharedStorage` (if the user moves the file from its original location, surely they should be responsible for tracking the new location?)

## Warning
I don't really write swift.  There were a lot of google searches like "swift unwrap optionals" and "swift anonymous function examples".  And I am still generally confused by their API versioning.  So this code could be terrible? 