### PR TITLE
Make version 8 work with Xcode 14

### DIFF
--- a/ios/Classes/BDPlugin.swift
+++ b/ios/Classes/BDPlugin.swift
@@ -153,11 +153,17 @@ public class BDPlugin: NSObject, FlutterPlugin, UNUserNotificationCenterDelegate
         os_log("%@ task with id %@", log: log, type: .info, verb, task.taskId)
         UrlSessionDelegate.createUrlSession()
         let url: URL?
+        // encodingInvalidCharacters is only available when compiling with Xcode 15, which uses Swift version 5.9
+        #if swift(>=5.9)
         if #available(iOS 17.0, *) {
             url = URL(string: task.url, encodingInvalidCharacters: false)
         } else {
             url = URL(string: task.url)
         }
+        #else
+        url = URL(string: task.url)
+        #endif
+        
         guard let url = url else
         {
             os_log("Invalid url: %@", log: log, type: .info, task.url)


### PR DESCRIPTION
Like we discussed in https://github.com/781flyingdutchman/background_downloader/issues/209

As you mentioned, there's no Xcode version gate in Swift, but a Swift version gate, so I used that, since Xcode 15 has a newer version of Swift. I hope that's reliable enough, if you disagree - no hard feelings, I'll just keep using this fork until I finally upgrade my mac.

Note: It compiles fine for me with Xcode 14 now, it'd be great if you could test if it works with Xcode 15 too since I don't have access to it. Thanks for all your help!