### PR TITLE
Removed minSdkVersion constraint (Fixes #211)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -50,10 +50,6 @@ android {
         main.java.srcDirs += 'src/main/kotlin'
     }
 
-    defaultConfig {
-        minSdkVersion 24
-    }
-
     namespace 'com.bbflight.background_downloader'
 }
 


### PR DESCRIPTION
The plugin works fine without the minSdkVersion constraint.
Fixes #211

