### PR TITLE
8.0.3 Bypass permissions on iOS (issue #213)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,34 @@
+## 8.0.3 Bypassing permissions on iOS
+
+By default, the downloader allows any of the permissions to be requested, but that also means that Apple requires you to add things like Photo Library Usage Description to your Info.plist, even if you never move files to the Photo Library.
+
+On iOS, to bypass the permission code altogether at compile time (and therefore remove the need to provide the Info.plist entry) modify your app's Podfile as follows:
+```agsl
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+    
+    # The following loop has been added to bypass compilation of specific
+    # permissions.
+    # If you want to bypass one or more permissions (so that you don't
+    # have to include things like a Photo Library Usage Description
+    # if you don't add files to the Photo Library) then add this loop
+    # and uncomment the permissions you want to bypass.
+    # If you bypass (by including the line below) then the
+    # check will not happen, and the permission is aways denied. If you
+    # bypass you do not need to include the associated entry in your
+    # Info.plist file
+    target.build_configurations.each do |config|
+      config.build_settings['OTHER_SWIFT_FLAGS'] ||= ['$(inherited)']
+      #config.build_settings['OTHER_SWIFT_FLAGS'] << '-D BYPASS_PERMISSION_NOTIFICATIONS'
+      #config.build_settings['OTHER_SWIFT_FLAGS'] << '-D BYPASS_PERMISSION_IOSADDTOPHOTOLIBRARY'
+      #config.build_settings['OTHER_SWIFT_FLAGS'] << '-D BYPASS_PERMISSION_IOSCHANGEPHOTOLIBRARY'
+      end
+  end
+end
+```
+and uncomment the line items that you want to bypass by deleting the `#` mark at the start of the line.
+
 ## 8.0.2 Allow compilation on XCode 14
 
 Add compiler version gate for Swift >=5.9

--- a/README.md
+++ b/README.md
@@ -630,6 +630,37 @@ The downloader will check permission status before each action, e.g. will not sh
 
 Note that permissions are very platform and version dependent, e.g. notification permissions on Android are only required as of API 33, and iOS 14 introduced new Photo Library permissions. If you want to get into details, you can determine the platform version you're running by calling `await FileDownloader().platformVersion()`.
 
+### Bypassing permissions on iOS
+
+By default, the downloader allows any of the permissions to be requested, but that also means that Apple requires you to add things like Photo Library Usage Description to your Info.plist, even if you never move files to the Photo Library.
+
+On iOS, to bypass the permission code altogether at compile time (and therefore remove the need to provide the Info.plist entry) modify your app's Podfile as follows:
+```agsl
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+    
+    # The following loop has been added to bypass compilation of specific
+    # permissions.
+    # If you want to bypass one or more permissions (so that you don't
+    # have to include things like a Photo Library Usage Description
+    # if you don't add files to the Photo Library) then add this loop
+    # and uncomment the permissions you want to bypass.
+    # If you bypass (by including the line below) then the
+    # check will not happen, and the permission is aways denied. If you
+    # bypass you do not need to include the associated entry in your
+    # Info.plist file
+    target.build_configurations.each do |config|
+      config.build_settings['OTHER_SWIFT_FLAGS'] ||= ['$(inherited)']
+      #config.build_settings['OTHER_SWIFT_FLAGS'] << '-D BYPASS_PERMISSION_NOTIFICATIONS'
+      #config.build_settings['OTHER_SWIFT_FLAGS'] << '-D BYPASS_PERMISSION_IOSADDTOPHOTOLIBRARY'
+      #config.build_settings['OTHER_SWIFT_FLAGS'] << '-D BYPASS_PERMISSION_IOSCHANGEPHOTOLIBRARY'
+      end
+  end
+end
+```
+and uncomment the line items that you want to bypass by deleting the `#` mark at the start of the line.
+
 ## Uploads
 
 Uploads are very similar to downloads, except:

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-# platform :ios, '11.0'
+platform :ios, '13.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'
@@ -37,5 +37,22 @@ end
 post_install do |installer|
   installer.pods_project.targets.each do |target|
     flutter_additional_ios_build_settings(target)
+    
+    # The following loop has been added to bypass compilation of specific
+    # permissions.
+    # If you want to bypass one or more permissions (so that you don't
+    # have to include things like a Photo Library Usage Description
+    # if you don't add files to the Photo Library) then add this loop
+    # and uncomment the permissions you want to bypass.
+    # If you bypass (by including the line below) then the
+    # check will not happen, and the permission is aways denied. If you
+    # bypass you do not need to include the associated entry in your
+    # Info.plist file
+    target.build_configurations.each do |config|
+      config.build_settings['OTHER_SWIFT_FLAGS'] ||= ['$(inherited)']
+      #config.build_settings['OTHER_SWIFT_FLAGS'] << '-D BYPASS_PERMISSION_NOTIFICATIONS'
+      #config.build_settings['OTHER_SWIFT_FLAGS'] << '-D BYPASS_PERMISSION_IOSADDTOPHOTOLIBRARY'
+      #config.build_settings['OTHER_SWIFT_FLAGS'] << '-D BYPASS_PERMISSION_IOSCHANGEPHOTOLIBRARY'
+      end
   end
 end


### PR DESCRIPTION
@Aulig I've implemented 'bypass' logic that allows you to set a flag in the Podfile to bypass the code for permission handling at compile time. This should make it possible to submit an app without reference to the Info.plist entry that would normally be required.

The approach is similar to the one you suggested, except by default we do ask for all permissions, so the flag is a 'bypass' flag that you have to enable to avoid compiling the permission code.

Can you please take a look at this PR and test it in your environment? Thanks!

