### PR TITLE
Add requiresConnectedNetwork for local API usage

### DIFF
--- a/android/src/main/kotlin/com/bbflight/background_downloader/BDPlugin.kt
+++ b/android/src/main/kotlin/com/bbflight/background_downloader/BDPlugin.kt
@@ -127,7 +127,7 @@ class BDPlugin : FlutterPlugin, MethodCallHandler, ActivityAware,
             }
             val data = dataBuilder.build()
             val constraints = Constraints.Builder().setRequiredNetworkType(
-                if (task.requiresWiFi) NetworkType.UNMETERED else NetworkType.CONNECTED
+                if (task.requiresConnectedNetwork) NetworkType.NOT_REQUIRED else if (task.requiresWiFi) NetworkType.UNMETERED else NetworkType.CONNECTED
             ).build()
             val requestBuilder =
                 if (task.isParallelDownloadTask())

--- a/android/src/main/kotlin/com/bbflight/background_downloader/Models.kt
+++ b/android/src/main/kotlin/com/bbflight/background_downloader/Models.kt
@@ -80,6 +80,7 @@ class Task(
     val baseDirectory: BaseDirectory,
     val group: String,
     val updates: Updates,
+    val requiresConnectedNetwork: Boolean = true,
     val requiresWiFi: Boolean = false,
     val retries: Int = 0,
     var retriesRemaining: Int = 0,
@@ -110,6 +111,7 @@ class Task(
         baseDirectory: BaseDirectory? = null,
         group: String? = null,
         updates: Updates? = null,
+        requiresConnectedNetwork: Boolean? = null,
         requiresWiFi: Boolean? = null,
         retries: Int? = null,
         retriesRemaining: Int? = null,
@@ -136,6 +138,7 @@ class Task(
             baseDirectory = baseDirectory ?: this.baseDirectory,
             group = group ?: this.group,
             updates = updates ?: this.updates,
+            requiresConnectedNetwork = requiresConnectedNetwork ?: this.requiresConnectedNetwork,
             requiresWiFi = requiresWiFi ?: this.requiresWiFi,
             retries = retries ?: this.retries,
             retriesRemaining = retriesRemaining ?: this.retriesRemaining,
@@ -331,7 +334,7 @@ class Task(
     fun hasFilename() = filename != "?"
 
     override fun toString(): String {
-        return "Task(taskId='$taskId', url='$url', filename='$filename', headers=$headers, httpRequestMethod=$httpRequestMethod, post=$post, fileField='$fileField', mimeType='$mimeType', fields=$fields, directory='$directory', baseDirectory=$baseDirectory, group='$group', updates=$updates, requiresWiFi=$requiresWiFi, retries=$retries, retriesRemaining=$retriesRemaining, allowPause=$allowPause, metaData='$metaData', creationTime=$creationTime, taskType='$taskType')"
+        return "Task(taskId='$taskId', url='$url', filename='$filename', headers=$headers, httpRequestMethod=$httpRequestMethod, post=$post, fileField='$fileField', mimeType='$mimeType', fields=$fields, directory='$directory', baseDirectory=$baseDirectory, group='$group', updates=$updates, requiresConnectedNetwork=$requiresConnectedNetwork, requiresWiFi=$requiresWiFi, retries=$retries, retriesRemaining=$retriesRemaining, allowPause=$allowPause, metaData='$metaData', creationTime=$creationTime, taskType='$taskType')"
     }
 
     /**

--- a/android/src/main/kotlin/com/bbflight/background_downloader/ParallelDownloadTaskWorker.kt
+++ b/android/src/main/kotlin/com/bbflight/background_downloader/ParallelDownloadTaskWorker.kt
@@ -481,6 +481,7 @@ class Chunk private constructor(
             updates = updatesBasedOnParent(parentTask),
             retries = parentTask.retries,
             retriesRemaining = parentTask.retries,
+            requiresConnectedNetwork = parentTask.requiresConnectedNetwork,
             requiresWiFi = parentTask.requiresWiFi,
             allowPause = parentTask.allowPause,
             priority = parentTask.priority,

--- a/example/integration_test/downloader_integration_test.dart
+++ b/example/integration_test/downloader_integration_test.dart
@@ -749,6 +749,7 @@ void main() {
           baseDirectory: BaseDirectory.temporary,
           group: 'someGroup',
           updates: Updates.statusAndProgress,
+          requiresConnectedNetwork: true,
           requiresWiFi: false,
           retries: 5,
           allowPause: false,
@@ -777,6 +778,8 @@ void main() {
         expect(task.baseDirectory, equals(complexTask.baseDirectory));
         expect(task.group, equals(complexTask.group));
         expect(task.updates, equals(complexTask.updates));
+        expect(task.requiresConnectedNetwork,
+            equals(complexTask.requiresConnectedNetwork));
         expect(task.requiresWiFi, equals(complexTask.requiresWiFi));
         expect(task.allowPause, equals(complexTask.allowPause));
         expect(task.retries, equals(complexTask.retries));
@@ -807,6 +810,7 @@ void main() {
           fields: {'name': 'value'},
           group: 'someGroup',
           updates: Updates.statusAndProgress,
+          requiresConnectedNetwork: true,
           requiresWiFi: false,
           retries: 1,
           metaData: 'someMetaData');
@@ -835,6 +839,8 @@ void main() {
         expect(task.baseDirectory, equals(complexTask.baseDirectory));
         expect(task.group, equals(complexTask.group));
         expect(task.updates, equals(complexTask.updates));
+        expect(task.requiresConnectedNetwork,
+            equals(complexTask.requiresConnectedNetwork));
         expect(task.requiresWiFi, equals(complexTask.requiresWiFi));
         expect(task.allowPause, equals(complexTask.allowPause));
         expect(task.retries, equals(complexTask.retries));

--- a/lib/src/chunk.dart
+++ b/lib/src/chunk.dart
@@ -44,6 +44,7 @@ class Chunk {
             retries: parentTask.retries,
             allowPause: parentTask.allowPause,
             priority: parentTask.priority,
+            requiresConnectedNetwork: parentTask.requiresConnectedNetwork,
             requiresWiFi: parentTask.requiresWiFi,
             metaData: jsonEncode({
               'parentTaskId': parentTask.taskId,

--- a/lib/src/task.dart
+++ b/lib/src/task.dart
@@ -217,6 +217,14 @@ sealed class Task extends Request implements Comparable {
   /// Type of progress updates desired
   final Updates updates;
 
+  /// If true, will not require an internet connected network to start task.
+  /// On Android, the NetworkType.CONNECTED constraint requires a valid internet
+  /// connection to start the task. If you're connected to a WiFi connection
+  /// which doesn't have external internet access but does have access to the
+  /// server you want to download/upload from (e.g., an API running on a local
+  /// IP) then setting this to true will allow the task to run.
+  final bool requiresConnectedNetwork;
+
   /// If true, will not download over cellular (metered) network
   final bool requiresWiFi;
 
@@ -260,6 +268,8 @@ sealed class Task extends Request implements Comparable {
   /// [group] if set allows different callbacks or processing for different
   /// groups
   /// [updates] the kind of progress updates requested
+  /// [requiresConnectedNetwork] if set, will start regardless of if device has
+  /// internet
   /// [requiresWiFi] if set, will not start download until WiFi is available.
   /// If not set may start download over cellular network
   /// [retries] if >0 will retry a failed download this many times
@@ -284,6 +294,7 @@ sealed class Task extends Request implements Comparable {
       this.baseDirectory = BaseDirectory.applicationDocuments,
       this.group = 'default',
       this.updates = Updates.status,
+      this.requiresConnectedNetwork = true,
       this.requiresWiFi = false,
       super.retries,
       this.metaData = '',
@@ -385,6 +396,7 @@ sealed class Task extends Request implements Comparable {
       BaseDirectory? baseDirectory,
       String? group,
       Updates? updates,
+      bool? requiresConnectedNetwork,
       bool? requiresWiFi,
       int? retries,
       int? retriesRemaining,
@@ -406,6 +418,7 @@ sealed class Task extends Request implements Comparable {
             BaseDirectory.values[(json['baseDirectory'] as num?)?.toInt() ?? 0],
         group = json['group'] ?? FileDownloader.defaultGroup,
         updates = Updates.values[(json['updates'] as num?)?.toInt() ?? 0],
+        requiresConnectedNetwork = json['requiresConnectedNetwork'] ?? true,
         requiresWiFi = json['requiresWiFi'] ?? false,
         allowPause = json['allowPause'] ?? false,
         priority = (json['priority'] as num?)?.toInt() ?? 5,
@@ -423,6 +436,7 @@ sealed class Task extends Request implements Comparable {
         'baseDirectory': baseDirectory.index, // stored as int
         'group': group,
         'updates': updates.index, // stored as int
+        'requiresConnectedNetwork': requiresConnectedNetwork,
         'requiresWiFi': requiresWiFi,
         'allowPause': allowPause,
         'priority': priority,
@@ -473,7 +487,7 @@ sealed class Task extends Request implements Comparable {
   @override
   String toString() {
     return '$taskType{taskId: $taskId, url: $url, filename: $filename, headers: '
-        '$headers, httpRequestMethod: $httpRequestMethod, post: ${post == null ? "null" : "not null"}, directory: $directory, baseDirectory: $baseDirectory, group: $group, updates: $updates, requiresWiFi: $requiresWiFi, retries: $retries, retriesRemaining: $retriesRemaining, allowPause: $allowPause, priority: $priority, metaData: $metaData, displayName: $displayName}';
+        '$headers, httpRequestMethod: $httpRequestMethod, post: ${post == null ? "null" : "not null"}, directory: $directory, baseDirectory: $baseDirectory, group: $group, updates: $updates, requiresConnectedNetwork: $requiresConnectedNetwork, requiresWiFi: $requiresWiFi, retries: $retries, retriesRemaining: $retriesRemaining, allowPause: $allowPause, priority: $priority, metaData: $metaData, displayName: $displayName}';
   }
 }
 
@@ -506,6 +520,8 @@ final class DownloadTask extends Task {
   /// [group] if set allows different callbacks or processing for different
   /// groups
   /// [updates] the kind of progress updates requested
+  /// [requiresConnectedNetwork] if set, will start regardless of if device has
+  /// internet
   /// [requiresWiFi] if set, will not start download until WiFi is available.
   /// If not set may start download over cellular network
   /// [retries] if >0 will retry a failed download this many times
@@ -526,6 +542,7 @@ final class DownloadTask extends Task {
       super.baseDirectory,
       super.group,
       super.updates,
+      super.requiresConnectedNetwork,
       super.requiresWiFi,
       super.retries,
       super.allowPause,
@@ -557,6 +574,7 @@ final class DownloadTask extends Task {
           BaseDirectory? baseDirectory,
           String? group,
           Updates? updates,
+          bool? requiresConnectedNetwork,
           bool? requiresWiFi,
           int? retries,
           int? retriesRemaining,
@@ -576,6 +594,8 @@ final class DownloadTask extends Task {
           baseDirectory: baseDirectory ?? this.baseDirectory,
           group: group ?? this.group,
           updates: updates ?? this.updates,
+          requiresConnectedNetwork:
+              requiresConnectedNetwork ?? this.requiresConnectedNetwork,
           requiresWiFi: requiresWiFi ?? this.requiresWiFi,
           retries: retries ?? this.retries,
           allowPause: allowPause ?? this.allowPause,
@@ -676,6 +696,8 @@ final class UploadTask extends Task {
   /// [group] if set allows different callbacks or processing for different
   /// groups
   /// [updates] the kind of progress updates requested
+  /// [requiresConnectedNetwork] if set, will start regardless of if device has
+  /// internet
   /// [requiresWiFi] if set, will not start upload until WiFi is available.
   /// If not set may start upload over cellular network
   /// [priority] in range 0 <= priority <= 10 with 0 highest, defaults to 5
@@ -698,6 +720,7 @@ final class UploadTask extends Task {
       super.baseDirectory,
       super.group,
       super.updates,
+      super.requiresConnectedNetwork,
       super.requiresWiFi,
       super.retries,
       super.priority,
@@ -782,6 +805,7 @@ final class UploadTask extends Task {
           BaseDirectory? baseDirectory,
           String? group,
           Updates? updates,
+          bool? requiresConnectedNetwork,
           bool? requiresWiFi,
           int? retries,
           int? retriesRemaining,
@@ -804,6 +828,8 @@ final class UploadTask extends Task {
           baseDirectory: baseDirectory ?? this.baseDirectory,
           group: group ?? this.group,
           updates: updates ?? this.updates,
+          requiresConnectedNetwork:
+              requiresConnectedNetwork ?? this.requiresConnectedNetwork,
           requiresWiFi: requiresWiFi ?? this.requiresWiFi,
           priority: priority ?? this.priority,
           retries: retries ?? this.retries,
@@ -867,6 +893,8 @@ final class MultiUploadTask extends UploadTask {
   /// [group] if set allows different callbacks or processing for different
   /// groups
   /// [updates] the kind of progress updates requested
+  /// [requiresConnectedNetwork] if set, will start regardless of if device has
+  /// internet
   /// [requiresWiFi] if set, will not start upload until WiFi is available.
   /// If not set may start upload over cellular network
   /// [priority] in range 0 <= priority <= 10 with 0 highest, defaults to 5
@@ -886,6 +914,7 @@ final class MultiUploadTask extends UploadTask {
       super.baseDirectory,
       super.group,
       super.updates,
+      super.requiresConnectedNetwork,
       super.requiresWiFi,
       super.priority,
       super.retries,
@@ -958,6 +987,7 @@ final class MultiUploadTask extends UploadTask {
           BaseDirectory? baseDirectory,
           String? group,
           Updates? updates,
+          bool? requiresConnectedNetwork,
           bool? requiresWiFi,
           int? priority,
           int? retries,
@@ -977,6 +1007,8 @@ final class MultiUploadTask extends UploadTask {
           baseDirectory: baseDirectory ?? this.baseDirectory,
           group: group ?? this.group,
           updates: updates ?? this.updates,
+          requiresConnectedNetwork:
+              requiresConnectedNetwork ?? this.requiresConnectedNetwork,
           requiresWiFi: requiresWiFi ?? this.requiresWiFi,
           priority: priority ?? this.priority,
           retries: retries ?? this.retries,
@@ -1024,6 +1056,8 @@ final class ParallelDownloadTask extends DownloadTask {
   /// [group] if set allows different callbacks or processing for different
   /// groups
   /// [updates] the kind of progress updates requested
+  /// [requiresConnectedNetwork] if set, will start regardless of if device has
+  /// internet
   /// [requiresWiFi] if set, will not start download until WiFi is available.
   /// If not set may start download over cellular network
   /// [retries] if >0 will retry a failed download this many times
@@ -1046,6 +1080,7 @@ final class ParallelDownloadTask extends DownloadTask {
       super.baseDirectory,
       super.group,
       super.updates,
+      super.requiresConnectedNetwork,
       super.requiresWiFi,
       super.retries,
       super.allowPause,
@@ -1094,6 +1129,7 @@ final class ParallelDownloadTask extends DownloadTask {
           BaseDirectory? baseDirectory,
           String? group,
           Updates? updates,
+          bool? requiresConnectedNetwork,
           bool? requiresWiFi,
           int? retries,
           int? retriesRemaining,
@@ -1113,6 +1149,8 @@ final class ParallelDownloadTask extends DownloadTask {
           baseDirectory: baseDirectory ?? this.baseDirectory,
           group: group ?? this.group,
           updates: updates ?? this.updates,
+          requiresConnectedNetwork:
+              requiresConnectedNetwork ?? this.requiresConnectedNetwork,
           requiresWiFi: requiresWiFi ?? this.requiresWiFi,
           retries: retries ?? this.retries,
           allowPause: allowPause ?? this.allowPause,

--- a/test/json_test.dart
+++ b/test/json_test.dart
@@ -21,15 +21,16 @@ final task = DownloadTask(
     directory: 'dir',
     group: 'group',
     updates: Updates.statusAndProgress,
+    requiresConnectedNetwork: true,
     requiresWiFi: true,
     retries: 5,
     allowPause: true,
     metaData: 'metaData',
     creationTime: DateTime.fromMillisecondsSinceEpoch(1000));
 const downloadTaskJsonString =
-    '{"url":"url?a=b","headers":{"c":"d"},"httpRequestMethod":"GET","post":null,"retries":5,"retriesRemaining":5,"creationTime":1000,"taskId":"taskId","filename":"filename","directory":"dir","baseDirectory":1,"group":"group","updates":3,"requiresWiFi":true,"allowPause":true,"priority":5,"metaData":"metaData","displayName":"","taskType":"DownloadTask"}';
+    '{"url":"url?a=b","headers":{"c":"d"},"httpRequestMethod":"GET","post":null,"retries":5,"retriesRemaining":5,"creationTime":1000,"taskId":"taskId","filename":"filename","directory":"dir","baseDirectory":1,"group":"group","updates":3,"requiresConnectedNetwork":true,"requiresWiFi":true,"allowPause":true,"priority":5,"metaData":"metaData","displayName":"","taskType":"DownloadTask"}';
 const downloadTaskJsonStringDoubles =
-    '{"url":"url?a=b","headers":{"c":"d"},"httpRequestMethod":"GET","post":null,"retries":5.0,"retriesRemaining":5.0,"creationTime":1000.0,"taskId":"taskId","filename":"filename","directory":"dir","baseDirectory":1.0,"group":"group","updates":3.0,"requiresWiFi":true,"allowPause":true,"metaData":"metaData","taskType":"DownloadTask"}';
+    '{"url":"url?a=b","headers":{"c":"d"},"httpRequestMethod":"GET","post":null,"retries":5.0,"retriesRemaining":5.0,"creationTime":1000.0,"taskId":"taskId","filename":"filename","directory":"dir","baseDirectory":1.0,"group":"group","updates":3.0,"requiresConnectedNetwork":true,"requiresWiFi":true,"allowPause":true,"metaData":"metaData","taskType":"DownloadTask"}';
 
 final uploadTask = UploadTask(
     taskId: 'taskId',
@@ -44,14 +45,15 @@ final uploadTask = UploadTask(
     directory: 'dir',
     group: 'group',
     updates: Updates.statusAndProgress,
+    requiresConnectedNetwork: true,
     requiresWiFi: true,
     retries: 5,
     metaData: 'metaData',
     creationTime: DateTime.fromMillisecondsSinceEpoch(1000));
 const uploadTaskJsonString =
-    '{"url":"url?a=b","headers":{"c":"d"},"httpRequestMethod":"PUT","post":null,"retries":5,"retriesRemaining":5,"creationTime":1000,"taskId":"taskId","filename":"filename","directory":"dir","baseDirectory":1,"group":"group","updates":3,"requiresWiFi":true,"allowPause":false,"priority":5,"metaData":"metaData","displayName":"","taskType":"UploadTask","fileField":"fileField","mimeType":"application/octet-stream","fields":{"e":"f"}}';
+    '{"url":"url?a=b","headers":{"c":"d"},"httpRequestMethod":"PUT","post":null,"retries":5,"retriesRemaining":5,"creationTime":1000,"taskId":"taskId","filename":"filename","directory":"dir","baseDirectory":1,"group":"group","updates":3,"requiresConnectedNetwork":true,"requiresWiFi":true,"allowPause":false,"priority":5,"metaData":"metaData","displayName":"","taskType":"UploadTask","fileField":"fileField","mimeType":"application/octet-stream","fields":{"e":"f"}}';
 const uploadTaskJsonStringDoubles =
-    '{"url":"url?a=b","headers":{"c":"d"},"httpRequestMethod":"PUT","post":null,"retries":5.0,"retriesRemaining":5.0,"creationTime":1000.0,"taskId":"taskId","filename":"filename","directory":"dir","baseDirectory":1.0,"group":"group","updates":3.0,"requiresWiFi":true,"allowPause":false,"metaData":"metaData","fileField":"fileField","mimeType":"application/octet-stream","fields":{"e":"f"},"taskType":"UploadTask"}';
+    '{"url":"url?a=b","headers":{"c":"d"},"httpRequestMethod":"PUT","post":null,"retries":5.0,"retriesRemaining":5.0,"creationTime":1000.0,"taskId":"taskId","filename":"filename","directory":"dir","baseDirectory":1.0,"group":"group","updates":3.0,"requiresConnectedNetwork":true,"requiresWiFi":true,"allowPause":false,"metaData":"metaData","fileField":"fileField","mimeType":"application/octet-stream","fields":{"e":"f"},"taskType":"UploadTask"}';
 
 void main() {
   group('JSON conversion', () {
@@ -169,7 +171,7 @@ void main() {
       final statusUpdate = TaskStatusUpdate(
           task, TaskStatus.failed, TaskConnectionException('test'));
       const expected =
-          '{"task":{"url":"url?a=b","headers":{"c":"d"},"httpRequestMethod":"GET","post":null,"retries":5,"retriesRemaining":5,"creationTime":1000,"taskId":"taskId","filename":"filename","directory":"dir","baseDirectory":1,"group":"group","updates":3,"requiresWiFi":true,"allowPause":true,"priority":5,"metaData":"metaData","displayName":"","taskType":"DownloadTask"},"taskStatus":4,"exception":{"type":"TaskConnectionException","description":"test"},"responseBody":null,"mimeType":null,"charSet":null}';
+          '{"task":{"url":"url?a=b","headers":{"c":"d"},"httpRequestMethod":"GET","post":null,"retries":5,"retriesRemaining":5,"creationTime":1000,"taskId":"taskId","filename":"filename","directory":"dir","baseDirectory":1,"group":"group","updates":3,"requiresConnectedNetwork":true,"requiresWiFi":true,"allowPause":true,"priority":5,"metaData":"metaData","displayName":"","taskType":"DownloadTask"},"taskStatus":4,"exception":{"type":"TaskConnectionException","description":"test"},"responseBody":null,"responseHeaders":null,"mimeType":null,"charSet":null}';
       expect(jsonEncode(statusUpdate.toJson()), equals(expected));
       final update2 = TaskStatusUpdate.fromJson(jsonDecode(expected));
       expect(update2.task, equals(statusUpdate.task));
@@ -177,7 +179,7 @@ void main() {
       expect(update2.exception?.description, equals('test'));
       expect(update2.exception is TaskConnectionException, isTrue);
       const withDoubles =
-          '{"url":"url?a=b","headers":{"c":"d"},"httpRequestMethod":"GET","post":null,"retries":5.0,"retriesRemaining":5.0,"creationTime":1000.0,"taskId":"taskId","filename":"filename","directory":"dir","baseDirectory":1.0,"group":"group","updates":3.0,"requiresWiFi":true,"allowPause":true,"metaData":"metaData","taskType":"DownloadTask","taskStatus":4.0,"exception":{"type":"TaskConnectionException","description":"test"}}';
+          '{"url":"url?a=b","headers":{"c":"d"},"httpRequestMethod":"GET","post":null,"retries":5.0,"retriesRemaining":5.0,"creationTime":1000.0,"taskId":"taskId","filename":"filename","directory":"dir","baseDirectory":1.0,"group":"group","updates":3.0,"requiresConnectedNetwork":true,"requiresWiFi":true,"allowPause":true,"metaData":"metaData","taskType":"DownloadTask","taskStatus":4.0,"exception":{"type":"TaskConnectionException","description":"test"}}';
       expect(
           jsonEncode(
               TaskStatusUpdate.fromJson(jsonDecode(withDoubles)).toJson()),
@@ -187,14 +189,14 @@ void main() {
     test('TaskProgressUpdate', () {
       final progressUpdate = TaskProgressUpdate(task, 1, 123);
       const expected =
-          '{"task":{"url":"url?a=b","headers":{"c":"d"},"httpRequestMethod":"GET","post":null,"retries":5,"retriesRemaining":5,"creationTime":1000,"taskId":"taskId","filename":"filename","directory":"dir","baseDirectory":1,"group":"group","updates":3,"requiresWiFi":true,"allowPause":true,"priority":5,"metaData":"metaData","displayName":"","taskType":"DownloadTask"},"progress":1.0,"expectedFileSize":123,"networkSpeed":-1.0,"timeRemaining":-1}';
+          '{"task":{"url":"url?a=b","headers":{"c":"d"},"httpRequestMethod":"GET","post":null,"retries":5,"retriesRemaining":5,"creationTime":1000,"taskId":"taskId","filename":"filename","directory":"dir","baseDirectory":1,"group":"group","updates":3,"requiresConnectedNetwork":true,"requiresWiFi":true,"allowPause":true,"priority":5,"metaData":"metaData","displayName":"","taskType":"DownloadTask"},"progress":1.0,"expectedFileSize":123,"networkSpeed":-1.0,"timeRemaining":-1}';
       expect(jsonEncode(progressUpdate.toJson()), equals(expected));
       final update2 = TaskProgressUpdate.fromJson(jsonDecode(expected));
       expect(update2.task, equals(progressUpdate.task));
       expect(update2.progress, equals(1));
       expect(update2.expectedFileSize, equals(123));
       const withDoubles =
-          '{"url":"url?a=b","headers":{"c":"d"},"httpRequestMethod":"GET","post":null,"retries":5.0,"retriesRemaining":5.0,"creationTime":1000.0,"taskId":"taskId","filename":"filename","directory":"dir","baseDirectory":1.0,"group":"group","updates":3.0,"requiresWiFi":true,"allowPause":true,"metaData":"metaData","taskType":"DownloadTask","progress":1,"expectedFileSize":123.0}';
+          '{"url":"url?a=b","headers":{"c":"d"},"httpRequestMethod":"GET","post":null,"retries":5.0,"retriesRemaining":5.0,"creationTime":1000.0,"taskId":"taskId","filename":"filename","directory":"dir","baseDirectory":1.0,"group":"group","updates":3.0,"requiresConnectedNetwork":true,"requiresWiFi":true,"allowPause":true,"metaData":"metaData","taskType":"DownloadTask","progress":1,"expectedFileSize":123.0}';
       expect(
           jsonEncode(
               TaskProgressUpdate.fromJson(jsonDecode(withDoubles)).toJson()),
@@ -205,7 +207,7 @@ void main() {
       final taskRecord =
           TaskRecord(task, TaskStatus.failed, 1, 123, TaskUrlException('test'));
       const expected =
-          '{"url":"url?a=b","headers":{"c":"d"},"httpRequestMethod":"GET","post":null,"retries":5,"retriesRemaining":5,"creationTime":1000,"taskId":"taskId","filename":"filename","directory":"dir","baseDirectory":1,"group":"group","updates":3,"requiresWiFi":true,"allowPause":true,"priority":5,"metaData":"metaData","displayName":"","taskType":"DownloadTask","status":4,"progress":1.0,"expectedFileSize":123,"exception":{"type":"TaskUrlException","description":"test"}}';
+          '{"url":"url?a=b","headers":{"c":"d"},"httpRequestMethod":"GET","post":null,"retries":5,"retriesRemaining":5,"creationTime":1000,"taskId":"taskId","filename":"filename","directory":"dir","baseDirectory":1,"group":"group","updates":3,"requiresConnectedNetwork":true,"requiresWiFi":true,"allowPause":true,"priority":5,"metaData":"metaData","displayName":"","taskType":"DownloadTask","status":4,"progress":1.0,"expectedFileSize":123,"exception":{"type":"TaskUrlException","description":"test"}}';
       expect(jsonEncode(taskRecord.toJson()), equals(expected));
       final update2 = TaskRecord.fromJson(jsonDecode(expected));
       expect(update2.task, equals(taskRecord.task));
@@ -215,7 +217,7 @@ void main() {
       expect(update2.progress, equals(1));
       expect(update2.expectedFileSize, equals(123));
       const withDoubles =
-          '{"url":"url?a=b","headers":{"c":"d"},"httpRequestMethod":"GET","post":null,"retries":5.0,"retriesRemaining":5.0,"creationTime":1000.0,"taskId":"taskId","filename":"filename","directory":"dir","baseDirectory":1,"group":"group","updates":3,"requiresWiFi":true,"allowPause":true,"metaData":"metaData","taskType":"DownloadTask","status":4.0,"progress":1,"expectedFileSize":123.0,"exception":{"type":"TaskUrlException","description":"test"}}';
+          '{"url":"url?a=b","headers":{"c":"d"},"httpRequestMethod":"GET","post":null,"retries":5.0,"retriesRemaining":5.0,"creationTime":1000.0,"taskId":"taskId","filename":"filename","directory":"dir","baseDirectory":1,"group":"group","updates":3,"requiresConnectedNetwork":true,"requiresWiFi":true,"allowPause":true,"metaData":"metaData","taskType":"DownloadTask","status":4.0,"progress":1,"expectedFileSize":123.0,"exception":{"type":"TaskUrlException","description":"test"}}';
       expect(jsonEncode(TaskRecord.fromJson(jsonDecode(withDoubles)).toJson()),
           equals(expected));
     });
@@ -223,7 +225,7 @@ void main() {
     test('ResumeData', () {
       final resumeData = ResumeData(task, 'data', 123, 'tag');
       const expected =
-          '{"task":{"url":"url?a=b","headers":{"c":"d"},"httpRequestMethod":"GET","post":null,"retries":5,"retriesRemaining":5,"creationTime":1000,"taskId":"taskId","filename":"filename","directory":"dir","baseDirectory":1,"group":"group","updates":3,"requiresWiFi":true,"allowPause":true,"priority":5,"metaData":"metaData","displayName":"","taskType":"DownloadTask"},"data":"data","requiredStartByte":123,"eTag":"tag"}';
+          '{"task":{"url":"url?a=b","headers":{"c":"d"},"httpRequestMethod":"GET","post":null,"retries":5,"retriesRemaining":5,"creationTime":1000,"taskId":"taskId","filename":"filename","directory":"dir","baseDirectory":1,"group":"group","updates":3,"requiresConnectedNetwork":true,"requiresWiFi":true,"allowPause":true,"priority":5,"metaData":"metaData","displayName":"","taskType":"DownloadTask"},"data":"data","requiredStartByte":123,"eTag":"tag"}';
       expect(jsonEncode(resumeData.toJson()), equals(expected));
       final update2 = ResumeData.fromJson(jsonDecode(expected));
       expect(update2.task, equals(resumeData.task));
@@ -231,12 +233,12 @@ void main() {
       expect(update2.requiredStartByte, equals(123));
       expect(update2.eTag, equals('tag'));
       const withDoubles =
-          '{"task":{"url":"url?a=b","headers":{"c":"d"},"httpRequestMethod":"GET","post":null,"retries":5.0,"retriesRemaining":5.0,"creationTime":1000.0,"taskId":"taskId","filename":"filename","directory":"dir","baseDirectory":1.0,"group":"group","updates":3.0,"requiresWiFi":true,"allowPause":true,"metaData":"metaData","taskType":"DownloadTask"},"data":"data","requiredStartByte":123.0,"eTag":"tag"}';
+          '{"task":{"url":"url?a=b","headers":{"c":"d"},"httpRequestMethod":"GET","post":null,"retries":5.0,"retriesRemaining":5.0,"creationTime":1000.0,"taskId":"taskId","filename":"filename","directory":"dir","baseDirectory":1.0,"group":"group","updates":3.0,"requiresConnectedNetwork":true,"requiresWiFi":true,"allowPause":true,"metaData":"metaData","taskType":"DownloadTask"},"data":"data","requiredStartByte":123.0,"eTag":"tag"}';
       expect(jsonEncode(ResumeData.fromJson(jsonDecode(withDoubles)).toJson()),
           equals(expected));
       final resumeData2 = ResumeData(task, 'data', 123, null);
       const expected2 =
-          '{"task":{"url":"url?a=b","headers":{"c":"d"},"httpRequestMethod":"GET","post":null,"retries":5,"retriesRemaining":5,"creationTime":1000,"taskId":"taskId","filename":"filename","directory":"dir","baseDirectory":1,"group":"group","updates":3,"requiresWiFi":true,"allowPause":true,"priority":5,"metaData":"metaData","displayName":"","taskType":"DownloadTask"},"data":"data","requiredStartByte":123,"eTag":null}';
+          '{"task":{"url":"url?a=b","headers":{"c":"d"},"httpRequestMethod":"GET","post":null,"retries":5,"retriesRemaining":5,"creationTime":1000,"taskId":"taskId","filename":"filename","directory":"dir","baseDirectory":1,"group":"group","updates":3,"requiresConnectedNetwork":true,"requiresWiFi":true,"allowPause":true,"priority":5,"metaData":"metaData","displayName":"","taskType":"DownloadTask"},"data":"data","requiredStartByte":123,"eTag":null}';
       expect(jsonEncode(resumeData2.toJson()), equals(expected2));
       final update3 = ResumeData.fromJson(jsonDecode(expected2));
       expect(update3.task, equals(resumeData.task));
@@ -247,7 +249,7 @@ void main() {
 
     test('DownloadTask incoming from Android', () {
       const incoming =
-          '{"allowPause":false,"baseDirectory": 1,"chunks":1,"creationTime":1694879914883,"directory":"","fields":{},"fileField":"","filename":"com.bbflight.background_downloader.1186323287","group":"chunk","headers":{"Range":"bytes\u003d0-29836749"},"httpRequestMethod":"GET","metaData":"{\\"parentTaskId\\":\\"3069222547\\",\\"from\\":0,\\"to\\":29836749}","mimeType":"","requiresWiFi":false,"retries":0,"retriesRemaining":0,"taskId":"1702658487","taskType":"DownloadTask","updates":2,"url":"https://storage.googleapis.com/approachcharts/test/57MB-test.ZIP","urls":[]}';
+          '{"allowPause":false,"baseDirectory": 1,"chunks":1,"creationTime":1694879914883,"directory":"","fields":{},"fileField":"","filename":"com.bbflight.background_downloader.1186323287","group":"chunk","headers":{"Range":"bytes\u003d0-29836749"},"httpRequestMethod":"GET","metaData":"{\\"parentTaskId\\":\\"3069222547\\",\\"from\\":0,\\"to\\":29836749}","mimeType":"","requiresConnectedNetwork":true,"requiresWiFi":false,"retries":0,"retriesRemaining":0,"taskId":"1702658487","taskType":"DownloadTask","updates":2,"url":"https://storage.googleapis.com/approachcharts/test/57MB-test.ZIP","urls":[]}';
       final task = Task.createFromJson(jsonDecode(incoming));
       print(task);
     });

--- a/test/task_test.dart
+++ b/test/task_test.dart
@@ -75,6 +75,7 @@ void main() {
         baseDirectory: BaseDirectory.temporary,
         group: 'someGroup',
         updates: Updates.statusAndProgress,
+        requiresConnectedNetwork: true,
         requiresWiFi: true,
         retries: 5,
         metaData: 'someMetaData');
@@ -92,6 +93,8 @@ void main() {
     expect(task.baseDirectory, equals(complexTask.baseDirectory));
     expect(task.group, equals(complexTask.group));
     expect(task.updates, equals(complexTask.updates));
+    expect(task.requiresConnectedNetwork,
+        equals(complexTask.requiresConnectedNetwork));
     expect(task.requiresWiFi, equals(complexTask.requiresWiFi));
     expect(task.retries, equals(complexTask.retries));
     expect(task.retriesRemaining, equals(complexTask.retriesRemaining));


### PR DESCRIPTION
Hi,

This pull request adds a new bool (requiresConnectedNetwork) to a task. What this does is sets setRequiredNetworkType inside BDPlugin.kt to NetworkType.NOT_REQUIRED.

Currently when using this library on a WiFi network which doesn't have an internet connection the task remains in an enqueued state forever and never starts (this is basically the same issue @thaivm  was having in https://github.com/781flyingdutchman/background_downloader/issues/188).

I have a WiFi access point set-up on a Raspberry Pi which runs an API that I want to download a file from it. The download URL is a local address, e.g., http://192.168.0.100/file.zip which is 100% accessible with my phone connected to that network. Because there's no internet connection Android flags the WiFi network as not having an internet connection and the current default of NetworkType.CONNECTED seems to actually mean "connected and has an internet connection". If I plug an ethernet lead into the Pi so it does get internet access then the file will successfully download.

I've only implemented it on Android, I'm not sure if iOS needs it?

Thanks