### PR TITLE
Fix typo on code example TaskQueue

### DIFF
--- a/README.md
+++ b/README.md
@@ -778,7 +778,7 @@ final tq = MemoryTaskQueue();
 tq.maxConcurrent = 5; // no more than 5 tasks active at any one time
 tq.maxConcurrentByHost = 2; // no more than two tasks talking to the same host at the same time
 tq.maxConcurrentByGroup = 3; // no more than three tasks from the same group active at the same time
-FileDownloader().add(tq); // 'connects' the TaskQueue to the FileDownloader
+FileDownloader().addTaskQueue(tq); // 'connects' the TaskQueue to the FileDownloader
 FileDownloader().updates.listen((update) { // listen to updates as per usual
   print('Received update for ${update.task.taskId}: $update')
 });


### PR DESCRIPTION
The README has code snippet error:

<img width="721" alt="Screenshot 2024-05-29 at 6 13 01 PM" src="https://github.com/781flyingdutchman/background_downloader/assets/60868965/277738da-13fd-431b-baaf-44eddf69eab1">

Correct:

<img width="506" alt="Screenshot 2024-05-29 at 6 13 22 PM" src="https://github.com/781flyingdutchman/background_downloader/assets/60868965/ed46bac4-a7a2-426c-83f6-6a623e853e2b">
