### PR TITLE
Fix an issue with task cancellation on MacOS & Content-Disposition encoding #376

### DIFF
--- a/lib/src/desktop/upload_isolate.dart
+++ b/lib/src/desktop/upload_isolate.dart
@@ -78,14 +78,16 @@ Future<TaskStatus> binaryUpload(
     transferBytesResult =
         await transferBytes(inStream, request.sink, fileSize, task, sendPort);
     request.sink.close(); // triggers request completion, handled above
-    await requestCompleter.future; // wait for request to complete
+
+    if (isCanceled) {
+      // cancellation overrides other results
+      resultStatus = TaskStatus.canceled;
+    } else {
+      await requestCompleter.future; // wait for request to complete
+    }
   } catch (e) {
     resultStatus = TaskStatus.failed;
     setTaskError(e);
-  }
-  if (isCanceled) {
-    // cancellation overrides other results
-    resultStatus = TaskStatus.canceled;
   }
   return resultStatus;
 }

--- a/lib/src/desktop/upload_isolate.dart
+++ b/lib/src/desktop/upload_isolate.dart
@@ -50,7 +50,7 @@ Future<TaskStatus> binaryUpload(
     request.contentLength = fileSize;
     request.headers['Content-Type'] = task.mimeType;
     request.headers['Content-Disposition'] =
-        'attachment; filename="${task.filename}"';
+        'attachment; filename="${Uri.encodeComponent(task.filename)}"';
     // initiate the request and handle completion async
     final requestCompleter = Completer();
     var transferBytesResult = TaskStatus.failed;
@@ -135,7 +135,7 @@ Future<TaskStatus> multipartUpload(
     }
     contentDispositionStrings.add(
       'Content-Disposition: form-data; name="${browserEncode(fileField)}"; '
-      'filename="${browserEncode(p.basename(file.path))}"$lineFeed',
+      'filename="${Uri.encodeComponent(browserEncode(p.basename(file.path)))}"$lineFeed',
     );
     contentTypeStrings.add('Content-Type: $mimeType$lineFeed$lineFeed');
     fileLengths.add(file.lengthSync());


### PR DESCRIPTION
The MacOS cancellation seems to be that `request.sink.close()` does not actually finish the request for some reason. Moving the request `await` outside cancellation logic seems fixes that.

Link to encoding issue: #376 