### PR TITLE
Workaround for iOS deadlocks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,118 @@
+name: Build the package
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  # This is Dart 3.0.x
+  FLUTTER_MIN_SDK: '3.10.6'
+
+jobs:
+  format:
+    name: "Check formatting"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          cache: true
+      - run: dart format --set-exit-if-changed .
+      - run: dart format --set-exit-if-changed example
+
+  lint:
+    name: "Check linting"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          cache: true
+      - run: flutter pub get
+      - run: flutter analyze
+      - run: flutter pub get
+        working-directory: example
+      - run: flutter analyze
+        working-directory: example
+
+  test:
+    name: "Run tests"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sdk: [ min, stable, beta ]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          cache: true
+          flutter-version: ${{ matrix.sdk == 'min' && env.FLUTTER_MIN_SDK || '' }}
+          channel: ${{ matrix.sdk == 'min' && 'stable' || matrix.sdk }}
+      - run: flutter pub get
+      - run: flutter test
+
+  build-android:
+    name: "Build Android example"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # The example Android project setup ist not supported by Flutter 3.10.x
+        sdk: [ stable, beta ]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'gradle'
+      - uses: subosito/flutter-action@v2
+        with:
+          cache: true
+          flutter-version: ${{ matrix.sdk == 'min' && env.FLUTTER_MIN_SDK || '' }}
+          channel: ${{ matrix.sdk == 'min' && 'stable' || matrix.sdk }}
+      - name: Build example APK
+        working-directory: example
+        run: flutter build apk
+      - name: Upload apk as artifact
+        uses: actions/upload-artifact@v4
+        if: ${{ matrix.sdk == 'stable' }}
+        with:
+          name: background-downloader-demo.apk
+          path: example/build/app/outputs/flutter-apk/app-release.apk
+
+  build-ios:
+    name: "Build iOS example"
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sdk: [ min, stable, beta ]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          cache: true
+          flutter-version: ${{ matrix.sdk == 'min' && env.FLUTTER_MIN_SDK || '' }}
+          channel: ${{ matrix.sdk == 'min' && 'stable' || matrix.sdk }}
+      - uses: maxim-lobanov/setup-cocoapods@v1
+        with:
+          podfile-path: example/ios/Podfile.lock
+      - name: Build example iOS package
+        run: flutter build ios --simulator
+        working-directory: example
+      - name: Upload Runner.app as artifact
+        if: ${{ matrix.sdk == 'stable' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: background-downloader-demo.app
+          path: example/build/ios/iphonesimulator

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,11 @@ migrate_working_dir/
 .dart_tool/
 .packages
 build/
+
+# FVM Version Cache
+.fvm/
+.fvmrc
+
+# Ruby/Bundler for cocoa pods
+.ruby-version
+Gemfile*

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,0 +1,35 @@
+PODS:
+  - background_downloader (0.0.1):
+    - Flutter
+  - Flutter (1.0.0)
+  - integration_test (0.0.1):
+    - Flutter
+  - path_provider_foundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
+
+DEPENDENCIES:
+  - background_downloader (from `.symlinks/plugins/background_downloader/ios`)
+  - Flutter (from `Flutter`)
+  - integration_test (from `.symlinks/plugins/integration_test/ios`)
+  - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
+
+EXTERNAL SOURCES:
+  background_downloader:
+    :path: ".symlinks/plugins/background_downloader/ios"
+  Flutter:
+    :path: Flutter
+  integration_test:
+    :path: ".symlinks/plugins/integration_test/ios"
+  path_provider_foundation:
+    :path: ".symlinks/plugins/path_provider_foundation/darwin"
+
+SPEC CHECKSUMS:
+  background_downloader: 9f788ffc5de45acf87d6380e91ca0841066c18cf
+  Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
+  integration_test: 252f60fa39af5e17c3aa9899d35d908a0721b573
+  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
+
+PODFILE CHECKSUM: 6eed05d5252b9951e6d41d9184373f50e56db08b
+
+COCOAPODS: 1.15.2

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2,6 +2,8 @@ PODS:
   - background_downloader (0.0.1):
     - Flutter
   - Flutter (1.0.0)
+  - flutter_isolate (0.0.1):
+    - Flutter
   - integration_test (0.0.1):
     - Flutter
   - path_provider_foundation (0.0.1):
@@ -11,6 +13,7 @@ PODS:
 DEPENDENCIES:
   - background_downloader (from `.symlinks/plugins/background_downloader/ios`)
   - Flutter (from `Flutter`)
+  - flutter_isolate (from `.symlinks/plugins/flutter_isolate/ios`)
   - integration_test (from `.symlinks/plugins/integration_test/ios`)
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
 
@@ -19,6 +22,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/background_downloader/ios"
   Flutter:
     :path: Flutter
+  flutter_isolate:
+    :path: ".symlinks/plugins/flutter_isolate/ios"
   integration_test:
     :path: ".symlinks/plugins/integration_test/ios"
   path_provider_foundation:
@@ -27,6 +32,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   background_downloader: 9f788ffc5de45acf87d6380e91ca0841066c18cf
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
+  flutter_isolate: 0edf5081826d071adf21759d1eb10ff5c24503b5
   integration_test: 252f60fa39af5e17c3aa9899d35d908a0721b573
   path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
 

--- a/example/lib/isolate.dart
+++ b/example/lib/isolate.dart
@@ -1,0 +1,50 @@
+import 'dart:math';
+
+import 'package:background_downloader/background_downloader.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_isolate/flutter_isolate.dart';
+
+/// This is the entry point for the background isolate.
+/// It downloads a single file and then waits a bit.
+@pragma('vm:entry-point')
+Future<void> backgroundIsolateEntryPoint(Object? _) async {
+  WidgetsFlutterBinding.ensureInitialized();
+  // await download();
+  await Future<void>.delayed(const Duration(seconds: 2));
+  return;
+}
+
+/// Downloads a file
+Future<void> download() async {
+  await FileDownloader()
+      .enqueue(
+        DownloadTask(
+          url:
+              'https://storage.googleapis.com/approachcharts/test/5MB-test.ZIP',
+          filename: 'File_${Random().nextInt(1000)}',
+          group: 'bunch',
+          updates: Updates.statusAndProgress,
+        ),
+      )
+      .timeout(const Duration(seconds: 2));
+}
+
+Future<String> testBackgroundUsage() async {
+  try {
+    // Download a file in foreground
+    await download();
+  } catch (e) {
+    return 'failure 1st: $e';
+  }
+
+  // Download a file in background
+  await flutterCompute(backgroundIsolateEntryPoint, 'dummy');
+
+  try {
+    // Download another file in foreground
+    await download();
+    return 'success';
+  } catch (e) {
+    return 'failure 2nd: $e';
+  }
+}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'dart:math';
 
 import 'package:background_downloader/background_downloader.dart';
+import 'package:background_downloader_example/isolate.dart';
 import 'package:flutter/material.dart';
 import 'package:logging/logging.dart';
 
@@ -35,6 +36,8 @@ class _MyAppState extends State<MyApp> {
 
   bool loadAndOpenInProgress = false;
   bool loadABunchInProgress = false;
+  bool loadBackgroundInProgress = false;
+  String? loadBackgroundResult;
 
   @override
   void initState() {
@@ -216,6 +219,27 @@ class _MyAppState extends State<MyApp> {
                             loadABunchInProgress ? null : processLoadABunch,
                         child: const Text('Load a bunch'))),
                 Center(child: Text(loadABunchInProgress ? 'Enqueueing' : '')),
+                const Divider(
+                  height: 30,
+                  thickness: 5,
+                  color: Colors.blueGrey,
+                ),
+                Center(
+                  child: ElevatedButton(
+                    onPressed:
+                        loadBackgroundInProgress ? null : processLoadBackground,
+                    child: const Text(
+                      'Load in background',
+                    ),
+                  ),
+                ),
+                Center(
+                  child: Text(
+                    loadBackgroundInProgress
+                        ? 'Working...'
+                        : loadBackgroundResult ?? '',
+                  ),
+                ),
               ],
             ),
           )),
@@ -362,6 +386,20 @@ class _MyAppState extends State<MyApp> {
       }
       setState(() {
         loadABunchInProgress = false;
+      });
+    }
+  }
+
+  Future<void> processLoadBackground() async {
+    if (!loadBackgroundInProgress) {
+      setState(() {
+        loadBackgroundInProgress = true;
+      });
+      await getPermission(PermissionType.notifications);
+      final result = await testBackgroundUsage();
+      setState(() {
+        loadBackgroundResult = result;
+        loadBackgroundInProgress = false;
       });
     }
   }

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -28,6 +28,9 @@ dependencies:
     # the parent directory to use the current plugin's version.
     path: ../
 
+  # This is used to create a background isolate
+  # with a separate entry point & Flutter engine for testing.
+  flutter_isolate: ^2.1.0
   logging: ^1.0.2
   provider: ^6.0.3
   path_provider: ^2.0.2

--- a/ios/Classes/BDPlugin.swift
+++ b/ios/Classes/BDPlugin.swift
@@ -53,7 +53,13 @@ public class BDPlugin: NSObject, FlutterPlugin, UNUserNotificationCenterDelegate
     
     public static func register(with registrar: FlutterPluginRegistrar) {
         let channel = FlutterMethodChannel(name: "com.bbflight.background_downloader", binaryMessenger: registrar.messenger())
-        backgroundChannel = FlutterMethodChannel(name: "com.bbflight.background_downloader.background", binaryMessenger: registrar.messenger())
+        if (backgroundChannel == nil) {
+            // This nil check fixes dead locking when used from multiple isolates
+            // by only tracking the primary isolate. This should in theory always
+            // be the Flutter main isolate.
+            // For full feature parity with Android see #382
+            backgroundChannel = FlutterMethodChannel(name: "com.bbflight.background_downloader.background", binaryMessenger: registrar.messenger())
+        }
         registrar.addMethodCallDelegate(instance, channel: channel)
         registrar.addApplicationDelegate(instance)
         let defaults = UserDefaults.standard


### PR DESCRIPTION
The PR is based on #384, I can rebase this once the other one is merged.

--- 

I added 2 separate commits:

[Add a multi isolate test to the example](https://github.com/781flyingdutchman/background_downloader/commit/6c59beb07ad2d7bd11b27ef0ccc7a42d1f86e2f0)

This commit adds a test case to the example which works fine on Android but fails on iOS.
On the first try the downloader will timeout on the 2nd foreground download.
On the second try the downloader will timeout on the 1st foreground download.
Completely killing/reinstalling the app fixes this until the button is pressed again.

[Workaround iOS dead locks](https://github.com/781flyingdutchman/background_downloader/commit/a5c0d3134b0c4fbc07337083fe8e11e2ec2aa84b)

This commit adds a workaround by checking if the `BDPlugin` is already register to an isolate before possibly setting the `backgroundChannel`. This prevents the deadlocks. This still does not bring iOS to feature parity with Android but is a first step.