### PR TITLE
Fix: closing open timer after task finished

### DIFF
--- a/android/src/main/kotlin/com/bbflight/background_downloader/TaskWorker.kt
+++ b/android/src/main/kotlin/com/bbflight/background_downloader/TaskWorker.kt
@@ -398,8 +398,6 @@ open class TaskWorker(
             timerForTimeOut?.schedule(taskTimeoutMillis) {
                 isTimedOut =
                     true // triggers .failed in [TransferBytes] method if not runInForeground
-                timerForTimeOut?.cancel()
-                timerForTimeOut?.purge()
             }
             task = Json.decodeFromString(inputData.getString(keyTask)!!)
             notificationConfigJsonString = inputData.getString(keyNotificationConfig)
@@ -535,11 +533,19 @@ open class TaskWorker(
                 )
 
                 is CancellationException -> {
-                    Log.i(
-                        TAG,
-                        "Canceled task with id ${task.taskId}: ${e.message}"
-                    )
-                    return TaskStatus.canceled
+                    if (BDPlugin.canceledTaskIds.contains(task.taskId)) {
+                        Log.i(
+                            TAG,
+                            "Canceled task with id ${task.taskId}: ${e.message}"
+                        )
+                        return TaskStatus.canceled
+                    } else {
+                        Log.i(
+                            TAG,
+                            "WorkManager CancellationException for task with id ${task.taskId} without manual cancellation: failing task"
+                        )
+                        return TaskStatus.failed
+                    }
                 }
 
                 else -> {


### PR DESCRIPTION
I maintain a app that focus on offline first, with a lot of images for the content (products, categories) all that images need to be downloaded in the initial step after login, per store average image (200), after adding the images to download in the queue, i noticie a lot of Timer thread open, more than hundread. The cause was Timer().schedule in TaskWorker, that is only closed after timeout (9 minutes), but hasnt closed after tasks finished.

- Scenario After calling queue add  hundreads times (Pay attention to "Timer-")
Thread Dump  before fix:
[threads_report.txt](https://github.com/user-attachments/files/18166414/threads_report.txt)
Thread Dump  after fix:
[threads_report_after.txt](https://github.com/user-attachments/files/18166413/threads_report_after.txt)

Maybe be related to #377 (Lot of Timer open locking android memory)

