### PR TITLE
fix: UploadTaskWorker.kt: upload big files

### DIFF
--- a/android/src/main/kotlin/com/bbflight/background_downloader/UploadTaskWorker.kt
+++ b/android/src/main/kotlin/com/bbflight/background_downloader/UploadTaskWorker.kt
@@ -443,7 +443,8 @@ class LimitedInputStream(
         }
 
         // Adjust length to not exceed limit
-        val maxBytesToRead = minOf(len, (limit - bytesRead).toInt())
+        val remainingBytes: Long = limit - bytesRead // Declare remainingBytes explicitly as a Long
+        val maxBytesToRead = minOf(len.toLong(), remainingBytes).toInt() // Safely cast after taking min
         val result = inputStream.read(b, off, maxBytesToRead)
 
         if (result != -1) {


### PR DESCRIPTION
When trying to upload big files (multiples GB). I got the following error:

```
D/FilePickerUtils(19963): File loaded and cached at:/data/user/0/com.bbflight.background_downloader_example/cache/file_picker/1736936002845/VID_20250115_110044.mp4
D/FilePickerDelegate(19963): File path:[com.mr.flutter.plugin.filepicker.FileInfo@ff33136]
I/flutter (19963): File saved to persistent storage: /data/user/0/com.bbflight.background_downloader_example/app_flutter/VID_20250115_110044.mp4
I/flutter (19963): File path before upload: /data/user/0/com.bbflight.background_downloader_example/app_flutter/VID_20250115_110044.mp4
I/BackgroundDownloader(19963): Enqueuing task with id 2321517675
D/HwCustConnectivityManagerImpl(19963): isBlockNetworkRequestByNonAis, INVALID_SUBSCRIPTION_ID
I/ConnectivityManager(19963): requestNetwork and the calling app is: com.bbflight.background_downloader_example
I/TaskWorker(19963): Starting task with taskId 2321517675
D/TaskWorker(19963): Binary upload for taskId 2321517675
I/TaskWorker(19963): Exception for taskId 2321517675: kotlinx.coroutines.JobCancellationException: DispatchedCoroutine is cancelling; job=DispatchedCoroutine{Cancelling}@7a3e140
W/TaskWorker(19963): Error for taskId 2321517675: length=8192; regionStart=0; regionLength=-568176788
W/TaskWorker(19963): java.lang.ArrayIndexOutOfBoundsException: length=8192; regionStart=0; regionLength=-568176788
W/TaskWorker(19963): 	at libcore.util.ArrayUtils.throwsIfOutOfBounds(ArrayUtils.java:40)
W/TaskWorker(19963): 	at libcore.io.IoBridge.read(IoBridge.java:508)
W/TaskWorker(19963): 	at java.io.FileInputStream.read(FileInputStream.java:313)
W/TaskWorker(19963): 	at com.bbflight.background_downloader.LimitedInputStream.read(UploadTaskWorker.kt:447)
W/TaskWorker(19963): 	at com.bbflight.background_downloader.TaskWorker$transferBytes$2$1.invokeSuspend(TaskWorker.kt:606)
W/TaskWorker(19963): 	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
```

It seems to have to do with the casting to an Int for `(limit - bytesRead).toInt()`.

The commit seems to fix the issue.

Thanks, for the awesome project.