### PR TITLE
Specifies Content-Type for 8-bit characters in Upload Requests (#459)

### DIFF
--- a/android/src/main/kotlin/com/bbflight/background_downloader/UploadTaskWorker.kt
+++ b/android/src/main/kotlin/com/bbflight/background_downloader/UploadTaskWorker.kt
@@ -17,7 +17,7 @@ class UploadTaskWorker(applicationContext: Context, workerParams: WorkerParamete
     TaskWorker(applicationContext, workerParams) {
 
     companion object {
-        private val asciiOnlyRegEx = Regex("^[\\x00-\\x7F]+$")
+        private val asciiOnlyRegEx = Regex("^[\\x00-\\xFF]+$")
         private val jsonStringRegEx = Regex("^\\s*(\\{.*\\}|\\[.*\\])\\s*$")
         private val newlineRegEx = Regex("\r\n|\r|\n")
         const val boundary = "-----background_downloader-akjhfw281onqciyhnIk"

--- a/ios/background_downloader/Sources/background_downloader/Uploader.swift
+++ b/ios/background_downloader/Sources/background_downloader/Uploader.swift
@@ -25,7 +25,7 @@ public class Uploader : NSObject, URLSessionTaskDelegate, StreamDelegate {
     var totalBytesWritten: Int64 = 0
     static let boundary = "-----background_downloader-akjhfw281onqciyhnIk"
     let lineFeed = "\r\n"
-    let asciiOnly = try! NSRegularExpression(pattern: "^[\\x00-\\x7F]+$")
+    let asciiOnly = try! NSRegularExpression(pattern: "^[\\x00-\\xFF]+$")
     let jsonString = try! NSRegularExpression(pattern: "^\\s*(\\{.*\\}|\\[.*\\])\\s*$")
     let newlineRegExp = try! NSRegularExpression(pattern: "\r\n|\r|\n")
     let bufferSize = 2 << 13


### PR DESCRIPTION
Addressing #459: extends character range from `"^[\\x00-\\x7F]+$"` to `"^[\\x00-\\xFF]+$"` so that 8-bit characters (such as ISO 8859-1) are also supported.