### PR TITLE
Fix a small issue with Task.isDownloadTask

### DIFF
--- a/android/src/main/kotlin/com/bbflight/background_downloader/Models.kt
+++ b/android/src/main/kotlin/com/bbflight/background_downloader/Models.kt
@@ -187,7 +187,7 @@ class Task(
                 updates == Updates.statusAndProgress
     }
 
-    /** True if this task is a DownloadTask or ParallelDownloadTask */
+    /** True if this task is a DownloadTask, UriDownloadTask or ParallelDownloadTask */
     fun isDownloadTask(): Boolean {
         return taskType == "DownloadTask" || taskType == "UriDownloadTask" || taskType == "ParallelDownloadTask"
     }

--- a/android/src/main/kotlin/com/bbflight/background_downloader/Models.kt
+++ b/android/src/main/kotlin/com/bbflight/background_downloader/Models.kt
@@ -189,7 +189,7 @@ class Task(
 
     /** True if this task is a DownloadTask or ParallelDownloadTask */
     fun isDownloadTask(): Boolean {
-        return taskType == "DownloadTask" || taskType == "ParallelDownloadTask"
+        return taskType == "DownloadTask" || taskType == "UriDownloadTask" || taskType == "ParallelDownloadTask"
     }
 
     /** True if this task is an UploadTask or MultiUploadTask */

--- a/ios/background_downloader/Sources/background_downloader/TaskFunctions.swift
+++ b/ios/background_downloader/Sources/background_downloader/TaskFunctions.swift
@@ -22,9 +22,7 @@ func providesStatusUpdates(downloadTask: Task) -> Bool {
     return downloadTask.updates == Updates.statusChange.rawValue || downloadTask.updates == Updates.statusChangeAndProgressUpdates.rawValue
 }
 
-/// True if this task is a DownloadTask, false if not
-///
-/// A ParallelDownloadTask is also a DownloadTask
+/// True if this task is a DownloadTask, UriDownloadTask or ParallelDownloadTask
 func isDownloadTask(task: Task) -> Bool {
     return task.taskType == "DownloadTask" || task.taskType == "UriDownloadTask" || task.taskType == "ParallelDownloadTask"
 }


### PR DESCRIPTION
Hey @781flyingdutchman thank you for this great package! I've been experimenting with `UriDownloadTask` and found it really useful compared to other approaches. This PR fixes a small issue in `isDownloadTask` method of `Task` class on Android side. It was causing the package to incorrectly show an upload icon in the notification but it might be affecting some other areas as well. I also updated the documentation on both iOS and Android sides to accurately reflect implementation detail.