### PR TITLE
Add notification update for upload task on iOS

### DIFF
--- a/ios/background_downloader/Sources/background_downloader/UrlSessionDelegate.swift
+++ b/ios/background_downloader/Sources/background_downloader/UrlSessionDelegate.swift
@@ -169,6 +169,8 @@ public class UrlSessionDelegate : NSObject, URLSessionDelegate, URLSessionDownlo
             : responseStatusCode == 404
             ? TaskStatus.notFound
             : TaskStatus.failed
+            let notificationType = finalStatus == .complete ? NotificationType.complete : NotificationType.error 
+            updateNotification(task: bgdTask, notificationType: notificationType, notificationConfig: notificationConfig)
             processStatusUpdate(task: bgdTask, status: finalStatus, taskException: taskException, responseBody: responseBody, responseHeaders: responseHeaders, responseStatusCode: responseStatusCode)
         }
     }


### PR DESCRIPTION
## 🔧 Fix Notification Type Based on Task Final Status

### 📝 Summary

This PR updates the logic that determines the notification type shown to the user upon upload task completion.

### ✅ Changes

- Added notification for upload task based on `finalStatus`

### 📌 Rationale

Previously, no notification was shown after an upload task finished. This update ensures that:

- A success notification (NotificationType.complete) is shown only when finalStatus == .complete.
- An error notification (NotificationType.error) is shown in all other cases (e.g., failed, canceled).

