### PR TITLE
Fix/do not use writeBytes as it does not work with utf8 strings

### DIFF
--- a/android/src/main/kotlin/com/bbflight/background_downloader/TaskWorker.kt
+++ b/android/src/main/kotlin/com/bbflight/background_downloader/TaskWorker.kt
@@ -551,9 +551,14 @@ open class TaskWorker(
 
         try {
             if ((task.isDownloadTask() || task.isDataTask()) && task.post != null) {
+                val bytes = task.post!!.toByteArray();
+
                 connection.doOutput = true
-                connection.setFixedLengthStreamingMode(lengthInBytes(task.post!!))
-                DataOutputStream(connection.outputStream).use { it.writeBytes(task.post) }
+                connection.setFixedLengthStreamingMode(bytes.size)
+                DataOutputStream(connection.outputStream).use {
+                    it.write(bytes)
+                    it.flush()
+                }
             }
             return process(connection)
         } catch (e: Exception) {


### PR DESCRIPTION
I encountered an error where I got unexpected end of stream errors when providing the data task with utf8 data on Android. Upon troubleshooting I narrowed the error down to this bit of code which previously used `writeBytes` method and passed the `task.post` directly to it which did not work with utf8 strings. 

I changed it so it writes the correctly utf8 encoded bytes from `toByteArray` method directly, which resolved the error for me.