### PR TITLE
fix: remove extra line between json header and value

### DIFF
--- a/android/src/main/kotlin/com/bbflight/background_downloader/UploadTaskWorker.kt
+++ b/android/src/main/kotlin/com/bbflight/background_downloader/UploadTaskWorker.kt
@@ -556,7 +556,7 @@ class UploadTaskWorker(applicationContext: Context, workerParams: WorkerParamete
         var header = "Content-Disposition: form-data; name=\"${browserEncode(name)}\""
         if (isJsonString(value)) {
             header = "$header\r\n" +
-                    "Content-Type: application/json; charset=utf-8\r\n"
+                    "Content-Type: application/json; charset=utf-8"
         } else if (!isPlainAscii(value)) {
             header = "$header\r\n" +
                     "Content-Type: text/plain; charset=utf-8\r\n" +

--- a/ios/background_downloader/Sources/background_downloader/Uploader.swift
+++ b/ios/background_downloader/Sources/background_downloader/Uploader.swift
@@ -194,7 +194,7 @@ public class Uploader : NSObject, URLSessionTaskDelegate, StreamDelegate {
          var header = "Content-Disposition: form-data; name=\"\(browserEncode(name))\""
         if isJsonString(value) {
             header = "\(header)\r\n" +
-            "Content-Type: application/json; charset=utf-8\r\n"
+            "Content-Type: application/json; charset=utf-8"
         } else if !isPlainAscii(value) {
             header = "\(header)\r\n" +
             "Content-Type: text/plain; charset=utf-8\r\n" +


### PR DESCRIPTION
When the field contains a JSON value, the encoded multipart entry had an additional line between the header and the value causing incorrect deserialisation on the server. It is not common to have two lines between the header and the value so this PR removes the additional line from both the iOS and Android implementation of the library