### PR TITLE
fix: use compactMap instead of force unwrapping an optional

### DIFF
--- a/ios/background_downloader/Sources/background_downloader/BDPlugin.swift
+++ b/ios/background_downloader/Sources/background_downloader/BDPlugin.swift
@@ -479,12 +479,12 @@ public class BDPlugin: NSObject, FlutterPlugin, UNUserNotificationCenterDelegate
         let group = call.arguments as? String
         var tasksAsListOfJsonStrings = [String]()
         await BDPlugin.holdingQueue?.stateLock.lock()
-        if let heldTasksJsonStrings = BDPlugin.holdingQueue?.allTasks(group: group).map({jsonStringFor(task: $0)}).filter({$0 != nil}).map({$0!}) {
+        if let heldTasksJsonStrings = BDPlugin.holdingQueue?.allTasks(group: group).compactMap({jsonStringFor(task: $0)}) {
             tasksAsListOfJsonStrings.append(contentsOf:  heldTasksJsonStrings)
         }
         UrlSessionDelegate.createUrlSession()
         if let urlSessionTasks = await UrlSessionDelegate.urlSession?.allTasks {
-            tasksAsListOfJsonStrings.append(contentsOf: urlSessionTasks.filter({ $0.state == .running || $0.state == .suspended }).map({ getTaskFrom(urlSessionTask: $0)}).filter({group == nil || $0?.group == group }).map({ jsonStringFor(task: $0!) }).filter({ $0 != nil }).map({$0!}))
+            tasksAsListOfJsonStrings.append(contentsOf: urlSessionTasks.filter({ $0.state == .running || $0.state == .suspended }).compactMap({ getTaskFrom(urlSessionTask: $0)}).filter({group == nil || $0.group == group }).compactMap({ jsonStringFor(task: $0) }))
         }
         await BDPlugin.holdingQueue?.stateLock.unlock()
         os_log("Returning %d unfinished tasks", log: log, type: .debug, tasksAsListOfJsonStrings.count)

--- a/ios/background_downloader/Sources/background_downloader/HoldingQueue.swift
+++ b/ios/background_downloader/Sources/background_downloader/HoldingQueue.swift
@@ -196,7 +196,7 @@ class HoldingQueue {
             await stateLock.unlock()
             return
         }
-        let tasks: [Task] = urlSessionTasks.filter({ $0.state != .completed }).map({ getTaskFrom(urlSessionTask: $0)}).filter({ $0 != nil}).map({ $0!})
+        let tasks: [Task] = urlSessionTasks.filter({ $0.state != .completed }).compactMap({ getTaskFrom(urlSessionTask: $0)})
         concurrent = tasks.count
         concurrentByHost.removeAll()
         concurrentByGroup.removeAll()

--- a/ios/background_downloader/Sources/background_downloader/UrlSessionDelegate.swift
+++ b/ios/background_downloader/Sources/background_downloader/UrlSessionDelegate.swift
@@ -548,7 +548,7 @@ public class UrlSessionDelegate : NSObject, URLSessionDelegate, URLSessionDownlo
     static func getAllTasks() async -> [Task] {
         UrlSessionDelegate.createUrlSession()
         guard let urlSessionTasks = await UrlSessionDelegate.urlSession?.allTasks else { return [] }
-        return urlSessionTasks.map({ getTaskFrom(urlSessionTask: $0) }).filter({ $0 != nil }) as? [Task] ?? []
+        return urlSessionTasks.compactMap({ getTaskFrom(urlSessionTask: $0) })
     }
     
     /// Return the active task with this taskId, or nil


### PR DESCRIPTION
### Description

The plugin crashes during runtime when an optional value is forcefully unwrapped but the actual value is `nil` in the following lines of code:

https://github.com/781flyingdutchman/background_downloader/blob/c44646d35c77d59664ca5292916eac657460520e/ios/background_downloader/Sources/background_downloader/BDPlugin.swift#L485-L488

This is because the `getTaskFrom` method returns an optional `Task` object which is forcefully unwrapped before passing it on to the `jsonStringFor` method.

This PR replaces all the instances of `filter != null -> map unwrap` handling to use [`compactMap`](https://developer.apple.com/documentation/swift/sequence/compactmap(_:))  instead.