### PR TITLE
Added options to DataTask

### DIFF
--- a/lib/src/task.dart
+++ b/lib/src/task.dart
@@ -536,7 +536,8 @@ sealed class Task extends Request implements Comparable {
       int? priority,
       String? metaData,
       String? displayName,
-      DateTime? creationTime});
+      DateTime? creationTime,
+      TaskOptions? options});
 
   /// Creates [Task] object from JsonMap
   ///
@@ -1409,7 +1410,8 @@ final class DataTask extends Task {
       super.metaData,
       super.displayName,
       super.priority,
-      super.creationTime})
+      super.creationTime,
+      super.options})
       : assert(const [Updates.status, Updates.none].contains(updates),
             'DataTasks can only provide status updates'),
         super(
@@ -1455,7 +1457,8 @@ final class DataTask extends Task {
           int? priority,
           String? metaData,
           String? displayName,
-          DateTime? creationTime}) =>
+          DateTime? creationTime,
+          TaskOptions? options}) =>
       DataTask(
           taskId: taskId ?? this.taskId,
           url: url ?? this.url,
@@ -1469,7 +1472,8 @@ final class DataTask extends Task {
           priority: priority ?? this.priority,
           metaData: metaData ?? this.metaData,
           displayName: displayName ?? this.displayName,
-          creationTime: creationTime ?? this.creationTime)
+          creationTime: creationTime ?? this.creationTime,
+          options: options ?? this.options)
         ..retriesRemaining = retriesRemaining ?? this.retriesRemaining;
 
   /// Creates [DataTask] object from [json]


### PR DESCRIPTION
This pull request adds support for passing a `TaskOptions` object to the `DataTask` class. The changes update constructors and copy methods to accept and handle the new `options` parameter, allowing for more flexible task configuration.

**Changes:**

* Updated the `DataTask` class constructor and its `copyWith` method to accept and propagate the `options` parameter, ensuring that option values are maintained when copying or creating new instances.