### PR TITLE
Remove flutter_isolate dependency from example app

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -31,7 +31,6 @@ dependencies:
 
   # This is used to create a background isolate
   # with a separate entry point & Flutter engine for testing.
-  flutter_isolate: ^2.1.0
   logging: ^1.0.2
   provider: ^6.0.3
   path_provider: ^2.0.2


### PR DESCRIPTION
Removed `flutter_isolate` dependency from `example/pubspec.yaml`.
Refactored `example/lib/isolate.dart` to use `Isolate.run` and `RootIsolateToken`.
Verified that `flutter analyze` passes.
Confirmed that full SPM migration for the example app is contingent on adding `Package.swift` to the `background_downloader` plugin.


---
*PR created automatically by Jules for task [9017172526049316348](https://jules.google.com/task/9017172526049316348) started by @781flyingdutchman*