### PR TITLE
Fix PathNotFoundException on Desktop macOS

### DIFF
--- a/lib/src/desktop/download_isolate.dart
+++ b/lib/src/desktop/download_isolate.dart
@@ -186,6 +186,7 @@ Future<TaskStatus> processOkDownloadResponse(
   IOSink? outStream;
   try {
     // do the actual download
+    Directory(p.dirname(tempFilePath)).createSync(recursive: true);
     outStream = File(
       tempFilePath,
     ).openWrite(mode: isResume ? FileMode.append : FileMode.write);


### PR DESCRIPTION
Fix PathNotFoundException on Desktop macOS by creating temp dir

On Desktop platforms (such as macOS), `getTemporaryDirectory()` might return a path with intermediate directories that do not yet exist. When `processOkDownloadResponse` attempts to `openWrite` the temporary file, it could fail with a `PathNotFoundException`. This change creates the parent directory of `tempFilePath` recursively prior to opening the file.

---
*PR created automatically by Jules for task [14898474147923327005](https://jules.google.com/task/14898474147923327005) started by @781flyingdutchman*