### PR TITLE
fix: Custom groups do not respect runInForeground on Android

### DIFF
--- a/android/src/main/kotlin/com/bbflight/background_downloader/Notifications.kt
+++ b/android/src/main/kotlin/com/bbflight/background_downloader/Notifications.kt
@@ -593,7 +593,7 @@ object NotificationService {
             stateChange = groupNotification.update(taskWorker.task, notificationType)
             groupNotifications[groupNotificationId] = groupNotification
         }
-        if (stateChange) {
+        if (stateChange || taskWorker.runInForeground) {
             // need to update the group notification
             taskWorker.notificationId = groupNotification.notificationId
             val hasError = groupNotification.hasError

--- a/android/src/main/kotlin/com/bbflight/background_downloader/TaskRunner.kt
+++ b/android/src/main/kotlin/com/bbflight/background_downloader/TaskRunner.kt
@@ -850,10 +850,16 @@ open class TaskRunner(
      * Based on [canRunInForeground] and [contentLength] > [runInForegroundFileSize]
      */
     fun determineRunInForeground(task: Task, contentLength: Long) {
+        val wasRunInForeground = runInForeground
         runInForeground =
             canRunInForeground && contentLength > (runInForegroundFileSize.toLong() shl 20)
         if (runInForeground) {
             Log.i(TAG, "TaskId ${task.taskId} will run in foreground")
+            if (!wasRunInForeground) {
+                CoroutineScope(Dispatchers.Default).launch {
+                    context.updateNotification(task, TaskStatus.running)
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Fixes an issue (#648) where tasks in custom groups on Android are demoted to regular background tasks instead of running in a foreground service when Config.runInForeground is used. This occurs because progress updates are filtered out for group notifications, preventing the foreground service from starting. The fix correctly triggers a foreground notification update when a task transitions to `runInForeground`, bypassing the group state change check.

---
*PR created automatically by Jules for task [9486845472882489351](https://jules.google.com/task/9486845472882489351) started by @781flyingdutchman*