### PR TITLE
Fix: iOS grouped notification identifier mismatch and data race in updateGroupNotification (fixes #656)

### DIFF
--- a/ios/background_downloader/Sources/background_downloader/Notifications.swift
+++ b/ios/background_downloader/Sources/background_downloader/Notifications.swift
@@ -224,13 +224,13 @@ func updateNotification(task: Task, notificationType: NotificationType, notifica
  * A group notification aggregates the state of all tasks in a group and
  * presents a notification based on that value
  */
-private func updateGroupNotification(
+@MainActor private func updateGroupNotification(
     task: Task,
     notificationType: NotificationType,
     notificationConfig: NotificationConfig
 ) async {
     let groupNotificationId = notificationConfig.groupNotificationId
-    var groupNotification = GroupNotification.notifications[groupNotificationId] ?? GroupNotification(name: groupNotificationId, notificationConfig: notificationConfig)
+    let groupNotification = GroupNotification.notifications[groupNotificationId] ?? GroupNotification(name: groupNotificationId, notificationConfig: notificationConfig)
     let stateChange = await groupNotification.update(task: task, notificationType: notificationType)
     GroupNotification.notifications[groupNotificationId] = groupNotification
     if stateChange {
@@ -261,15 +261,16 @@ private func updateGroupNotification(
         // check if the notification title or body have changed relative to what may
         // already be delivered, to avoid flashing notifications without change
         let existingNotifications = await notificationCenter.deliveredNotifications()
+        let notificationIdForGroup = await groupNotification.notificationId
         let previousNotification = existingNotifications.filter { 
-            $0.request.identifier == groupNotificationId
+            $0.request.identifier == notificationIdForGroup
         }
         if previousNotification.isEmpty || previousNotification.first?.request.content.title != content.title || previousNotification.first?.request.content.body != content.body
         {
             if !isFinished {
                 addCancelActionToNotificationGroup(content: content)
             }
-            let request = UNNotificationRequest(identifier: await groupNotification.notificationId,
+            let request = UNNotificationRequest(identifier: notificationIdForGroup,
                                                 content: content, trigger: nil)
             do {
                 try await notificationCenter.add(request)


### PR DESCRIPTION
## Summary

- Fixes the identifier mismatch in `updateGroupNotification` that prevented deduplication of already-delivered iOS grouped notifications. The delivered-notification filter compared `request.identifier` against the raw `groupNotificationId` (e.g. `app_documents_group`), but notifications are scheduled with the prefixed `GroupNotification.notificationId` (e.g. `groupNotification:app_documents_group`). The filter now uses the same prefixed identifier, so unchanged content is correctly skipped.
- Marks `updateGroupNotification` as `@MainActor` to fix a data race on the static `GroupNotification.notifications` dictionary. This function was previously a plain `async` function with no actor isolation, yet it could be called concurrently from `updateNotification` (already `@MainActor`) and from `registerEnqueue` (called on arbitrary executors via `HoldingQueue` and `BDPlugin`). The unsynchronized concurrent access to the dictionary could cause `EXC_BAD_ACCESS`. Adding `@MainActor` serializes all reads and writes to the main thread, consistent with how `updateNotification` already calls this function.

Fixes https://github.com/781flyingdutchman/background_downloader/issues/656

## Test plan

- [ ] Configure a `NotificationConfig` with a non-empty `groupNotificationId` (grouped notification mode) on iOS
- [ ] Enqueue several downloads that trigger multiple `updateGroupNotification` calls while a notification is already delivered
- [ ] Verify that identical group notifications are **not** re-posted (no repeated banners or sounds for unchanged content)
- [ ] Verify that group notifications **are** updated when the title or body actually changes (e.g. progress count changes)
- [ ] Rapidly enqueue many tasks (e.g. 50+) to exercise concurrent calls from `HoldingQueue` and confirm no `EXC_BAD_ACCESS` crashes