### PR TITLE
fix(ios): resolve group notification identifier mismatch during deduplication

### DIFF
--- a/ios/background_downloader/Sources/background_downloader/Notifications.swift
+++ b/ios/background_downloader/Sources/background_downloader/Notifications.swift
@@ -261,8 +261,9 @@ private func updateGroupNotification(
         // check if the notification title or body have changed relative to what may
         // already be delivered, to avoid flashing notifications without change
         let existingNotifications = await notificationCenter.deliveredNotifications()
+        let notificationId = await groupNotification.notificationId
         let previousNotification = existingNotifications.filter { 
-            $0.request.identifier == groupNotificationId
+            $0.request.identifier == notificationId
         }
         if previousNotification.isEmpty || previousNotification.first?.request.content.title != content.title || previousNotification.first?.request.content.body != content.body
         {


### PR DESCRIPTION
This fixes the bug reported in issue #656 where iOS grouped notifications had mismatched identifiers when filtering existing ones, causing the library to constantly re-add unchanged notifications.

The identifier used for group notification creation is `"groupNotification:\(name)"`, which in code is handled by `await groupNotification.notificationId`. By storing it locally before filtering (since `filter` does not take an async block in this context), we can correctly match the prefixed identifier string against the notification requests.

---
*PR created automatically by Jules for task [3941566031347259047](https://jules.google.com/task/3941566031347259047) started by @781flyingdutchman*