### PR TITLE
fix(android): move WorkManager.get() off main thread in onAttachedToEngine

### DIFF
--- a/android/src/main/kotlin/com/bbflight/background_downloader/BDPlugin.kt
+++ b/android/src/main/kotlin/com/bbflight/background_downloader/BDPlugin.kt
@@ -544,19 +544,27 @@ class BDPlugin : FlutterPlugin, MethodCallHandler, ActivityAware,
             "com.bbflight.background_downloader.uriutils"
         )
         uriUtilsChannel.setMethodCallHandler(UriUtilsMethodCallHelper(this))
-        // clear expired items
         val prefs = PreferenceManager.getDefaultSharedPreferences(applicationContext)
-        val workManager = WorkManager.getInstance(applicationContext)
-        val allWorkInfos = workManager.getWorkInfosByTag(TAG).get()
-        if (allWorkInfos.isEmpty()) {
-            prefsLock.write {
-                // remove persistent storage if no jobs found at all
-                prefs.edit {
-                    remove(keyTasksMap)
+        requireWifi = RequireWiFi.entries[prefs.getInt(keyRequireWiFi, 0)]
+        // clear expired items - moved off the main thread because
+        // WorkManager.getWorkInfosByTag(...).get() blocks until the WorkManager
+        // executor responds, which can stall the UI thread on cold start
+        // (especially after the Flutter Great Thread Merge where plugin
+        // callbacks run on Main).
+        defaultScope.launch {
+            val workManager = WorkManager.getInstance(applicationContext)
+            val allWorkInfos = withContext(Dispatchers.IO) {
+                workManager.getWorkInfosByTag(TAG).get()
+            }
+            if (allWorkInfos.isEmpty()) {
+                prefsLock.write {
+                    // remove persistent storage if no jobs found at all
+                    prefs.edit {
+                        remove(keyTasksMap)
+                    }
                 }
             }
         }
-        requireWifi = RequireWiFi.entries[prefs.getInt(keyRequireWiFi, 0)]
     }
 
 


### PR DESCRIPTION
Addresses finding #1 from #670.

## Problem

`BDPlugin.onAttachedToEngine` runs on the Main thread. The current code calls:

```kotlin
val allWorkInfos = workManager.getWorkInfosByTag(TAG).get()
```

`.get()` blocks until WorkManager's internal executor responds. On cold start, when WorkManager is initializing its Room DB, this can stall the UI for hundreds of ms. With Flutter's Great Thread Merge, that stall is now directly on the UI thread.

The result is only used to optionally clear stale prefs — nothing in `onAttachedToEngine` depends on it synchronously.

## Fix

Dispatch the lookup to `defaultScope.launch { withContext(Dispatchers.IO) { ... } }`. `requireWifi` is read from prefs **before** the dispatch to preserve startup ordering (it was set last in the original).

## Risk

Low. `requireWifi` is set before the async block, so all synchronous startup semantics are preserved. The async cleanup only writes to prefs (`SharedPreferences` is thread-safe; access is also guarded by `prefsLock`).

## Test plan

- `flutter build apk --debug` in `example/` passes
- Not runtime-tested for the prefs cleanup path itself (it's a corner case requiring stale-but-orphaned `keyTasksMap` entries to verify); the path is unchanged in behavior, only the thread it runs on.

Linked: #670
