### PR TITLE
ci: resolve node 20 deprecation by forcing node 24 in workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,14 +18,13 @@ concurrency:
 env:
   # This is Dart 3.7.0
   FLUTTER_MIN_SDK: '3.29.0'
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   format:
     name: "Check formatting"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: subosito/flutter-action@v2
         with:
           cache: true
@@ -39,7 +38,7 @@ jobs:
     name: "Check linting"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: subosito/flutter-action@v2
         with:
           cache: true
@@ -59,8 +58,8 @@ jobs:
       matrix:
         sdk: [ min, stable, beta ]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -75,7 +74,7 @@ jobs:
         working-directory: example
         run: flutter build apk
       - name: Upload apk as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: ${{ matrix.sdk == 'stable' }}
         with:
           name: background-downloader-demo.apk
@@ -89,7 +88,7 @@ jobs:
       matrix:
         sdk: [ min, stable, beta ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: subosito/flutter-action@v2
         with:
           cache: true
@@ -103,7 +102,7 @@ jobs:
         working-directory: example
       - name: Upload Runner.app as artifact
         if: ${{ matrix.sdk == 'stable' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: background-downloader-demo.app
           path: example/build/ios/iphonesimulator
@@ -116,7 +115,7 @@ jobs:
       matrix:
         sdk: [ stable, beta ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: subosito/flutter-action@v2
         with:
           cache: true
@@ -135,7 +134,7 @@ jobs:
         working-directory: example
       - name: Upload example Linux package as artifact
         if: ${{ matrix.sdk == 'stable' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: background-downloader-demo-linux
           path: example/build/linux/x64/release/bundle

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,7 @@ concurrency:
 env:
   # This is Dart 3.7.0
   FLUTTER_MIN_SDK: '3.29.0'
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   format:

--- a/.github/workflows/issue-metrics.yml
+++ b/.github/workflows/issue-metrics.yml
@@ -8,6 +8,9 @@ permissions:
   issues: write
   pull-requests: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     name: issue metrics

--- a/.github/workflows/issue-metrics.yml
+++ b/.github/workflows/issue-metrics.yml
@@ -8,9 +8,6 @@ permissions:
   issues: write
   pull-requests: read
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   build:
     name: issue metrics
@@ -32,13 +29,13 @@ jobs:
           echo "last_month=$first_day..$last_day" >> "$GITHUB_ENV"  
 
       - name: Run issue-metrics tool for issues and prs opened last month
-        uses: github/issue-metrics@v2
+        uses: github/issue-metrics@v4
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SEARCH_QUERY: 'repo:781flyingdutchman/background_downloader created:${{ env.last_month }} -reason:"not planned"'
 
       - name: Create issue for opened issues and prs
-        uses: peter-evans/create-issue-from-file@v4
+        uses: peter-evans/create-issue-from-file@v6
         with:
           title: Monthly issue metrics report for opened issues and prs
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -46,13 +43,13 @@ jobs:
           assignees: 781flyingdutchman
 
       - name: Run issue-metrics tool for issues and prs closed last month
-        uses: github/issue-metrics@v2
+        uses: github/issue-metrics@v4
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SEARCH_QUERY: 'repo:781flyingdutchman/background_downloader closed:${{ env.last_month }} -reason:"not planned"'
 
       - name: Create issue for closed issues and prs
-        uses: peter-evans/create-issue-from-file@v4
+        uses: peter-evans/create-issue-from-file@v6
         with:
           title: Monthly issue metrics report for closed issues and prs
           content-filepath: ./issue_metrics.md

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -11,20 +11,17 @@ on:
 permissions:
   issues: write
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   triage-issue:
     runs-on: ubuntu-latest
     steps:
       # Step 1: Check out the repository's code
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Step 2: Set up Python environment
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
 

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -11,6 +11,9 @@ on:
 permissions:
   issues: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   triage-issue:
     runs-on: ubuntu-latest

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,6 +3,9 @@ on:
   schedule:
     - cron: "35 1 * * *"
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   close-issues:
     runs-on: ubuntu-latest

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,9 +3,6 @@ on:
   schedule:
     - cron: "35 1 * * *"
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   close-issues:
     runs-on: ubuntu-latest
@@ -13,7 +10,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v5
+      - uses: actions/stale@v10
         with:
           days-before-issue-stale: 14
           days-before-issue-close: 7


### PR DESCRIPTION
This PR resolves the Node.js 20 deprecation warning in GitHub Actions. By setting the `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` environment variable across all workflow files (`build.yml`, `issue-metrics.yml`, `issue-triage.yml`, and `stale.yml`), actions will now be forced to use Node.js 24.

---
*PR created automatically by Jules for task [5715626973121816610](https://jules.google.com/task/5715626973121816610) started by @781flyingdutchman*