### PR TITLE
fix(android): Correct ETag used for ResumeData and fix weak ETag check

### DIFF
--- a/android/src/main/kotlin/com/bbflight/background_downloader/DownloadTaskRunner.kt
+++ b/android/src/main/kotlin/com/bbflight/background_downloader/DownloadTaskRunner.kt
@@ -101,7 +101,7 @@ class DownloadTaskRunner(context: TaskJobContext) : TaskRunner(context) {
                 deleteTempFile()
                 return TaskStatus.failed
             }
-            if (isResume && (eTagHeader != eTag || eTag?.subSequence(0, 1) == "W/")) {
+            if (isResume && (eTagHeader != eTag || eTag?.startsWith("W/") == true)) {
                 deleteTempFile()
                 Log.i(TAG, "Cannot resume: ETag is not identical, or is weak")
                 taskException = TaskException(
@@ -343,7 +343,7 @@ class DownloadTaskRunner(context: TaskJobContext) : TaskRunner(context) {
                             context.appContext,
                             task,
                             notificationConfigJsonString,
-                            ResumeData(task, tempFilePath, start, eTag),
+                            ResumeData(task, tempFilePath, start, eTagHeader),
                             1000
                         )
                         return TaskStatus.paused


### PR DESCRIPTION
Fixes issue #683 where an incorrect ETag variable was stored during a timeout-pause, breaking auto-resume on first-run long downloads. It also resolves a bug where the weak ETag validation guard was ineffective due to an incorrect substring check.

---
*PR created automatically by Jules for task [15876652117260973094](https://jules.google.com/task/15876652117260973094) started by @781flyingdutchman*