### PR TITLE
fix: graceful fallback for kotlin-android plugin on AGP 9+

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,7 +4,8 @@ plugins {
 }
 
 def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
-if (agpMajor < 9) {
+def isBuiltInKotlinFalse = project.hasProperty('builtInKotlin') && (project.property('builtInKotlin') == false || project.property('builtInKotlin') == 'false')
+if (agpMajor < 9 || isBuiltInKotlinFalse) {
     apply plugin: ['kotlin', 'android'].join('-')
 }
 


### PR DESCRIPTION
This PR resolves issue #674 by modifying the Android Gradle Plugin configuration for the `background_downloader` plugin. Starting in AGP 9.0+, built-in Kotlin is the default, and applying the legacy `kotlin-android` plugin causes compilation errors. However, some developers may opt out of this by setting `builtInKotlin=false`. To support those users, this patch detects the `builtInKotlin` property and correctly falls back to the legacy plugin if it is explicitly disabled, preventing compilation errors.

---
*PR created automatically by Jules for task [1477768699846335167](https://jules.google.com/task/1477768699846335167) started by @781flyingdutchman*