### PR TITLE
Fix ConcurrentModificationException in canSendCancellation

### DIFF
--- a/android/src/main/kotlin/com/bbflight/background_downloader/BDPlugin.kt
+++ b/android/src/main/kotlin/com/bbflight/background_downloader/BDPlugin.kt
@@ -48,6 +48,7 @@ import java.net.MalformedURLException
 import java.net.URL
 import java.net.URLDecoder
 import java.util.Collections
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.locks.ReentrantReadWriteLock
 import kotlin.concurrent.read
@@ -106,8 +107,13 @@ class BDPlugin : FlutterPlugin, MethodCallHandler, ActivityAware,
         var requireWifi = RequireWiFi.asSetByTask // global setting
         val localResumeData =
             Collections.synchronizedMap(mutableMapOf<String, ResumeData>()) // by taskId, for pause notifications
-        var cancelUpdateSentForTaskId =
-            Collections.synchronizedMap(mutableMapOf<String, Long>()) // <taskId, timeMillis>
+        // ConcurrentHashMap (not synchronizedMap): canSendCancellation prunes stale
+        // entries by iterating this map, and synchronizedMap does not synchronize
+        // iteration, which raced with concurrent status-update processing and threw
+        // ConcurrentModificationException. ConcurrentHashMap's iterators are
+        // weakly-consistent and never throw CME.
+        val cancelUpdateSentForTaskId =
+            ConcurrentHashMap<String, Long>() // <taskId, timeMillis>
         val pausedTaskIds =
             Collections.synchronizedSet(mutableSetOf<String>()) // <taskId>, acts as flag
         val canceledTaskIds =

--- a/android/src/main/kotlin/com/bbflight/background_downloader/TaskRunner.kt
+++ b/android/src/main/kotlin/com/bbflight/background_downloader/TaskRunner.kt
@@ -303,8 +303,12 @@ open class TaskRunner(
          */
         private fun canSendCancellation(task: Task): Boolean {
             val now = currentTimeMillis()
-            BDPlugin.cancelUpdateSentForTaskId =
-                BDPlugin.cancelUpdateSentForTaskId.filter { now - it.value < 3000 } as MutableMap
+            // Prune stale entries in place. cancelUpdateSentForTaskId is a
+            // ConcurrentHashMap, so removing while iterating is safe even when other
+            // workers are processing status updates concurrently (the previous
+            // reassignment via .filter{} iterated a synchronizedMap without holding
+            // its monitor and threw ConcurrentModificationException).
+            BDPlugin.cancelUpdateSentForTaskId.entries.removeAll { now - it.value >= 3000 }
             return BDPlugin.cancelUpdateSentForTaskId[task.taskId] == null
         }
 


### PR DESCRIPTION
## Problem

We see this crash on Android (v9.5.6) during downloads with concurrency, when a cancellation is processed:

```
java.util.ConcurrentModificationException
    at java.util.LinkedHashMap$LinkedHashIterator.nextNode
    at kotlin.collections.MapsKt__MapsKt.filterTo
    at TaskRunner$Companion.canSendCancellation(TaskRunner.kt:307)
    at TaskRunner$Companion.processStatusUpdate(TaskRunner.kt:199)
    at BDPlugin$Companion.cancelActiveTaskWithId(BDPlugin.kt:423)
```

## Cause

`BDPlugin.cancelUpdateSentForTaskId` is a `Collections.synchronizedMap(...)`. `synchronizedMap` synchronizes individual operations but **not iteration** — callers must hold the map's monitor while iterating. `canSendCancellation` rebuilds the map with `.filter { }`, which iterates the entrySet **without** `synchronized(map){}`. It runs on every status update (`processStatusUpdate`), so with several concurrent downloads a simultaneous `put` (TaskRunner.kt:201) or `remove` (BDPlugin.kt:154) from another worker mutates the map mid-iteration → CME.

## Fix

Make `cancelUpdateSentForTaskId` a `ConcurrentHashMap` (weakly-consistent iterators never throw CME) and prune stale entries **in place** via `entries.removeAll { }` instead of reassigning via `filter`. Same semantics (drop entries older than 3s); all other accesses (`put`, `containsKey`, `remove`, `get`) are unchanged and ConcurrentHashMap-safe (no null keys/values involved).