### PR TITLE
fix: defer JsonProcessor idle shutdown while requests are pending

### DIFF
--- a/lib/src/json_processor.dart
+++ b/lib/src/json_processor.dart
@@ -169,19 +169,21 @@ class JsonProcessor {
   }
 
   void _shutdown() {
+    if (_pendingCompleters.isNotEmpty) {
+      // Requests are still in flight (the isolate may be starved of CPU under
+      // heavy load, e.g. during a large download on a memory-pressured
+      // device). Killing it now would fail those requests with a StateError
+      // that surfaces as an unhandled 'Background isolate shut down' error in
+      // the app. Defer the shutdown instead; the timer is reset again when a
+      // request completes.
+      _resetShutdownTimer();
+      return;
+    }
     _isolate?.kill();
     _isolate = null;
     _sendPort = null;
     _shutdownTimer?.cancel();
     _shutdownTimer = null;
-
-    // Fail any pending requests
-    for (final completer in _pendingCompleters.values) {
-      if (!completer.isCompleted) {
-        completer.completeError(StateError('Background isolate shut down'));
-      }
-    }
-    _pendingCompleters.clear();
   }
 }
 


### PR DESCRIPTION
Fixes #689.

`_shutdown()` now re-arms the idle timer and returns when `_pendingCompleters` is non-empty, instead of killing the isolate and failing every in-flight request with `StateError('Background isolate shut down')`. The isolate is only killed once genuinely idle.

Rationale: the helper isolate does pure CPU-bound JSON work — no I/O, no platform channels — and its own exceptions are already caught in `_isolateMain` and returned per-request, so a pending request always resolves once the isolate gets CPU time. The only state the old watchdog "protected" against was slowness (e.g. a memory-pressured device mid large batch download), which it converted into lost status updates and an unhandled `StateError` surfacing in the host app.

Tested: existing `json_processor_test.dart` and `json_processor_concurrency_test.dart` pass unchanged; running in production-shaped end-to-end installs (1.5 GB batch, backgrounding, network interruption) via a fork.

🤖 Generated with [Claude Code](https://claude.com/claude-code)