### PR TITLE
fix: serialize access to GroupNotification registry (EXC_BAD_ACCESS)

### DIFF
--- a/ios/background_downloader/Sources/background_downloader/Notifications.swift
+++ b/ios/background_downloader/Sources/background_downloader/Notifications.swift
@@ -42,7 +42,31 @@ enum NotificationType : Int {
 
 /// Data and methods related to a notification for a group of tasks
 actor GroupNotification {
-    static var notifications: [String : GroupNotification] = [:]
+    private static var registry: [String : GroupNotification] = [:]
+    private static let registryLock = NSLock()
+
+    /// Atomically gets (or creates and registers) the notification for this
+    /// group. Serialised via a lock: this is called concurrently from
+    /// [updateGroupNotification] for every task status update, and
+    /// unsynchronised access to the shared dictionary corrupts it
+    /// (EXC_BAD_ACCESS).
+    static func groupNotification(named name: String, notificationConfig: NotificationConfig) -> GroupNotification {
+        registryLock.lock()
+        defer { registryLock.unlock() }
+        if let existing = registry[name] {
+            return existing
+        }
+        let created = GroupNotification(name: name, notificationConfig: notificationConfig)
+        registry[name] = created
+        return created
+    }
+
+    /// Removes the notification for this group from the registry
+    static func remove(named name: String) {
+        registryLock.lock()
+        defer { registryLock.unlock() }
+        registry.removeValue(forKey: name)
+    }
 
     let name: String
     let notificationConfig: NotificationConfig
@@ -230,9 +254,8 @@ private func updateGroupNotification(
     notificationConfig: NotificationConfig
 ) async {
     let groupNotificationId = notificationConfig.groupNotificationId
-    var groupNotification = GroupNotification.notifications[groupNotificationId] ?? GroupNotification(name: groupNotificationId, notificationConfig: notificationConfig)
+    let groupNotification = GroupNotification.groupNotification(named: groupNotificationId, notificationConfig: notificationConfig)
     let stateChange = await groupNotification.update(task: task, notificationType: notificationType)
-    GroupNotification.notifications[groupNotificationId] = groupNotification
     if stateChange {
         // need to update the group notification
         let notificationCenter = UNUserNotificationCenter.current()
@@ -282,7 +305,7 @@ private func updateGroupNotification(
             // remove only if not re-activated within 5 seconds
             try? await _Concurrency.Task.sleep(nanoseconds: 5_000_000_000)
             if await groupNotification.isFinished {
-                GroupNotification.notifications.removeValue(forKey: groupNotificationId)
+                GroupNotification.remove(named: groupNotificationId)
             }
         }
     }


### PR DESCRIPTION
## The race

`GroupNotification` is an actor, so its instance state is isolated — but its registry is a plain static mutable dictionary:

```swift
actor GroupNotification {
    static var notifications: [String : GroupNotification] = [:]
```

Static stored properties on an actor are not actor-isolated. `updateGroupNotification` runs concurrently on the global executor for every task status update in a batch download, and it reads (line 233), writes (line 235), and removes (line 285) entries in that dictionary with no synchronization. Concurrent mutation of a Swift `Dictionary` corrupts its storage.

Production evidence (Crashlytics, iPhone 13 Pro / iOS 18.6.2, during a multi-file batch download):

```
EXC_BAD_ACCESS (KERN_INVALID_ADDRESS)
at updateGroupNotification(task:notificationType:notificationConfig:) (Notifications.swift:233)
at swift::runJobInEstablishedExecutorContext(swift::Job*)
```

There is also a second, silent symptom: two concurrent calls can both miss the registry entry, each create a fresh `GroupNotification` actor for the same group, and split their task updates across the two instances — producing wrong group counts even when nothing crashes.

## The fix

The registry becomes private, guarded by an `NSLock` held only across dictionary operations (never across an `await`), with an atomic get-or-create (`groupNotification(named:notificationConfig:)`) and `remove(named:)`. Since the actor is a reference type, the racy read-modify-write-back pattern at lines 233–235 collapses into a single atomic lookup, which also fixes the duplicate-instance symptom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)