### PR TITLE
Fix group notification sticking when cancelling tasks from holding queue

### DIFF
--- a/android/src/main/kotlin/com/bbflight/background_downloader/HoldingQueue.kt
+++ b/android/src/main/kotlin/com/bbflight/background_downloader/HoldingQueue.kt
@@ -18,6 +18,7 @@ import java.util.concurrent.PriorityBlockingQueue
 import java.util.concurrent.atomic.AtomicInteger
 import android.app.job.JobScheduler
 import android.os.Build
+import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
 /**
@@ -150,6 +151,14 @@ class HoldingQueue(private val context: Context, private val workManager: WorkMa
         toRemove.forEach {
             queue.remove(it)
             TaskWorker.processStatusUpdate(it.task, TaskStatus.canceled, prefs, context = context)
+            if (it.notificationConfigJsonString != null) {
+                NotificationService.createUpdateNotificationWorker(
+                    context,
+                    Json.encodeToString(it.task),
+                    it.notificationConfigJsonString,
+                    TaskStatus.canceled.ordinal
+                )
+            }
             Log.i(BDPlugin.TAG, "Canceled task with id ${it.task.taskId}")
         }
         removedTaskIds = toRemove.map { it.task.taskId }.toMutableList()

--- a/ios/background_downloader/Sources/background_downloader/HoldingQueue.swift
+++ b/ios/background_downloader/Sources/background_downloader/HoldingQueue.swift
@@ -88,6 +88,12 @@ class HoldingQueue {
         let toRemove = queue.filter( { taskIds.contains($0.task.taskId) } )
         toRemove.forEach { item in
             processStatusUpdate(task: item.task, status: .canceled)
+            if let configString = item.notificationConfigJsonString,
+               let config = notificationConfigFrom(jsonString: configString) {
+                _Concurrency.Task {
+                    await updateGroupNotification(task: item.task, notificationType: .canceled, notificationConfig: config)
+                }
+            }
             os_log("Canceled task with id %@", log: log, type: .info, item.task.taskId)
         }
         queue.removeAll(where: { taskIds.contains($0.task.taskId)})

--- a/ios/background_downloader/Sources/background_downloader/Notifications.swift
+++ b/ios/background_downloader/Sources/background_downloader/Notifications.swift
@@ -248,7 +248,7 @@ func updateNotification(task: Task, notificationType: NotificationType, notifica
  * A group notification aggregates the state of all tasks in a group and
  * presents a notification based on that value
  */
-private func updateGroupNotification(
+func updateGroupNotification(
     task: Task,
     notificationType: NotificationType,
     notificationConfig: NotificationConfig


### PR DESCRIPTION
Fixes https://github.com/781flyingdutchman/background_downloader/issues/688

When Config.holdingQueue is enabled and a group notification is used, cancelling tasks that sit in the holding queue previously left the group's running notification stuck on screen indefinitely because `numFinished` never reached `numTotal`.

The enqueue path adds the task to the group-notification count, but the holding-queue cancel path never removed it. This patch explicitly updates the notification service on cancellation in both Android (`HoldingQueue.kt`) and iOS (`HoldingQueue.swift`).

---
*PR created automatically by Jules for task [1646885036318833428](https://jules.google.com/task/1646885036318833428) started by @781flyingdutchman*