### PR TITLE
Fix PrivacyInfo.xcprivacy typo for photos and videos data collection

### DIFF
--- a/ios/background_downloader/Sources/background_downloader/PrivacyInfo.xcprivacy
+++ b/ios/background_downloader/Sources/background_downloader/PrivacyInfo.xcprivacy
@@ -10,7 +10,7 @@
     <array>
         <dict>
             <key>NSPrivacyCollectedDataType</key>
-            <string>NSPrivacyCollectedDataTypePhotosOrVideos</string>
+            <string>NSPrivacyCollectedDataTypePhotosorVideos</string>
             <key>NSPrivacyCollectedDataTypeLinked</key>
             <false/>
             <key>NSPrivacyCollectedDataTypeTracking</key>


### PR DESCRIPTION
Fix PrivacyInfo.xcprivacy typo for photos and videos data collection where `NSPrivacyCollectedDataTypePhotosOrVideos` (camel-case) was used instead of the correct `NSPrivacyCollectedDataTypePhotosorVideos` (lowercase 'o'). This fixes App Store validation errors.

Fixes #694

---
*PR created automatically by Jules for task [9503256568067537403](https://jules.google.com/task/9503256568067537403) started by @781flyingdutchman*