### PR TITLE
Add `alsoRestartUploads` parameter to `requireWiFi`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 9.5.8
+
+* Add `alsoRestartUploads` parameter to `FileDownloader.requireWiFi` to optionally cancel and restart running upload tasks when updating WiFi requirement (fixes #695)
+* [iOS] Fixes typo in `PrivacyInfo.xcprivacy` for photos and videos data collection key (`NSPrivacyCollectedDataTypePhotosorVideos`), resolving App Store submission validation errors (fixes #694)
+* [Documentation] Adds comprehensive documentation for `TaskStatusUpdate` and `TaskProgressUpdate` in `doc/status_updates.md` (fixes #684)
+
 ## 9.5.7
 
 * [Android] Bug fixes:

--- a/android/src/main/kotlin/com/bbflight/background_downloader/BDPlugin.kt
+++ b/android/src/main/kotlin/com/bbflight/background_downloader/BDPlugin.kt
@@ -1200,11 +1200,13 @@ class BDPlugin : FlutterPlugin, MethodCallHandler, ActivityAware,
         val args = call.arguments as List<*>
         val newRequireWiFi = RequireWiFi.entries[args[0] as Int]
         val rescheduleRunning = args[1] as Boolean
+        val alsoRestartUploads = args[2] as Boolean
         WiFi.requireWiFiChange(
             RequireWiFiChange(
                 applicationContext,
                 newRequireWiFi,
-                rescheduleRunning
+                rescheduleRunning,
+                alsoRestartUploads
             )
         )
         true

--- a/android/src/main/kotlin/com/bbflight/background_downloader/WiFi.kt
+++ b/android/src/main/kotlin/com/bbflight/background_downloader/WiFi.kt
@@ -73,7 +73,8 @@ object WiFi {
 class RequireWiFiChange(
     private val applicationContext: Context,
     private val requireWifi: RequireWiFi,
-    private val rescheduleRunningTasks: Boolean
+    private val rescheduleRunningTasks: Boolean,
+    private val alsoRestartUploads: Boolean
 ) {
     /**
      * Execute the change in WiFi requirement and return
@@ -96,7 +97,7 @@ class RequireWiFiChange(
             if (tags.isNotEmpty()) {
                 val taskId = tags.first().substring(7)
                 val task = tasksMap[taskId]
-                if (task != null && task.isDownloadTask()) {
+                if (task != null && (task.isDownloadTask() || task.isUploadTask())) {
                     if (BDPlugin.taskRequiresWifi(task) != BDPlugin.taskIdsRequiringWiFi.contains(
                             task.taskId
                         )
@@ -120,10 +121,21 @@ class RequireWiFiChange(
                             }
 
                             WorkInfo.State.RUNNING -> {
-                                if (rescheduleRunningTasks) {
+                                if (rescheduleRunningTasks && task.isDownloadTask()) {
                                     haveReEnqueued = true
                                     BDPlugin.tasksToReEnqueue.add(task)
                                     BDPlugin.pauseTaskWithId(task.taskId)
+                                } else if (alsoRestartUploads && task.isUploadTask()) {
+                                    haveReEnqueued = true
+                                    BDPlugin.tasksToReEnqueue.add(task)
+                                    if (!BDPlugin.cancelActiveTaskWithId(
+                                            applicationContext,
+                                            task.taskId,
+                                            workManager
+                                        )
+                                    ) {
+                                        BDPlugin.tasksToReEnqueue.remove(task)
+                                    }
                                 }
                             }
 

--- a/doc/lifecycle.md
+++ b/doc/lifecycle.md
@@ -111,7 +111,7 @@ By default, whether a task requires WiFi or not is determined by its `requireWiF
 * `forAllTasks` requires WiFi for all tasks
 * `forNoTasks` does not require WiFi for any tasks
 
-When calling `FileDownloader().requireWifi`, all enqueued tasks will be canceled and rescheduled with the appropriate WiFi requirement setting, and if the `rescheduleRunningTasks` parameter is true, all running tasks will be paused (if possible, independent of the task's `allowPause` property) or canceled and resumed/restarted with the new WiFi requirement. All newly enqueued tasks will follow this setting as well.
+When calling `FileDownloader().requireWiFi`, all enqueued tasks will be canceled and rescheduled with the appropriate WiFi requirement setting. If the `rescheduleRunningTasks` parameter is true, all running download tasks will be paused (if possible, independent of the task's `allowPause` property) and resumed with the new WiFi requirement. If the `alsoRestartUploads` parameter is true (which requires `rescheduleRunningTasks` to also be true), running upload tasks will be forcefully canceled and restarted from scratch. All newly enqueued tasks will follow this setting as well.
 
 The global setting persists across application restarts. Check the current setting by calling `FileDownloader().getRequireWiFiSetting`.
 

--- a/ios/background_downloader/Sources/background_downloader/BDPlugin.swift
+++ b/ios/background_downloader/Sources/background_downloader/BDPlugin.swift
@@ -793,7 +793,8 @@ public class BDPlugin: NSObject, FlutterPlugin, UNUserNotificationCenterDelegate
             return
         }
         let rescheduleRunning = args[1] as? Bool ?? false
-        WiFiQueue.shared.requireWiFiChange(requireWiFi: newRequireWiFi, rescheduleRunningTasks: rescheduleRunning)
+        let alsoRestartUploads = args.count > 2 ? args[2] as? Bool ?? false : false
+        WiFiQueue.shared.requireWiFiChange(requireWiFi: newRequireWiFi, rescheduleRunningTasks: rescheduleRunning, alsoRestartUploads: alsoRestartUploads)
         result(true)
     }
     

--- a/ios/background_downloader/Sources/background_downloader/WiFi.swift
+++ b/ios/background_downloader/Sources/background_downloader/WiFi.swift
@@ -27,7 +27,7 @@ class WiFiQueue {
     private init() {}
     
     // Change the application level WiFi requirement and re-enqueue tasks as necessary
-    func requireWiFiChange(requireWiFi: RequireWiFi, rescheduleRunningTasks: Bool) {
+    func requireWiFiChange(requireWiFi: RequireWiFi, rescheduleRunningTasks: Bool, alsoRestartUploads: Bool) {
         requireWiFiChangeQueue.async {
             _Concurrency.Task {
                 BDPlugin.requireWiFi = requireWiFi
@@ -41,7 +41,7 @@ class WiFiQueue {
                 }
                 var haveReEnqueued = false
                 urlSessionTasks.forEach { urlSessionTask in
-                    if (urlSessionTask is URLSessionDownloadTask && (urlSessionTask.state == .running || urlSessionTask.state == .suspended)) {
+                    if ((urlSessionTask is URLSessionDownloadTask || urlSessionTask is URLSessionUploadTask) && (urlSessionTask.state == .running || urlSessionTask.state == .suspended)) {
                         guard let task = getTaskFrom(urlSessionTask: urlSessionTask) else {
                             return
                         }
@@ -59,13 +59,17 @@ class WiFiQueue {
                                     BDPlugin.tasksToReEnqueue.insert(task)
                                     urlSessionTask.cancel()
                                 } else {
-                                    if rescheduleRunningTasks {
+                                    if rescheduleRunningTasks && isDownloadTask(task: task) {
                                         // already running, so pause instead of cancel
                                         haveReEnqueued = true
                                         BDPlugin.tasksToReEnqueue.insert(task)
                                         _Concurrency.Task{
                                             await (urlSessionTask as! URLSessionDownloadTask).cancelByProducingResumeData()
                                         }
+                                    } else if alsoRestartUploads && isUploadTask(task: task) {
+                                        haveReEnqueued = true
+                                        BDPlugin.tasksToReEnqueue.insert(task)
+                                        urlSessionTask.cancel()
                                     }
                                 }
                             }

--- a/lib/src/base_downloader.dart
+++ b/lib/src/base_downloader.dart
@@ -674,11 +674,16 @@ abstract base class BaseDownloader {
   /// Set WiFi requirement globally, based on [requirement].
   ///
   /// Affects future tasks and reschedules enqueued, inactive tasks
-  /// with the new setting.
-  /// Reschedules running tasks if [rescheduleRunningTasks] is true,
-  /// otherwise leaves those running with their prior setting
-  Future<bool> requireWiFi(RequireWiFi requirement, rescheduleRunningTasks) =>
-      Future.value(true);
+  /// (both downloads and uploads) with the new setting.
+  /// Reschedules running download tasks if [rescheduleRunningTasks] is true,
+  /// otherwise leaves those running with their prior setting.
+  /// Restarts running upload tasks if [alsoRestartUploads] is true (which
+  /// requires [rescheduleRunningTasks] to be true as well).
+  Future<bool> requireWiFi(
+    RequireWiFi requirement,
+    rescheduleRunningTasks,
+    alsoRestartUploads,
+  ) => Future.value(true);
 
   /// Returns the current global setting for requiring WiFi
   Future<RequireWiFi> getRequireWiFiSetting() =>

--- a/lib/src/file_downloader.dart
+++ b/lib/src/file_downloader.dart
@@ -796,13 +796,26 @@ interface class FileDownloader {
   /// Set WiFi requirement globally, based on [requirement].
   ///
   /// Affects future tasks and reschedules enqueued, inactive tasks
-  /// with the new setting.
-  /// Reschedules running tasks if [rescheduleRunningTasks] is true,
-  /// otherwise leaves those running with their prior setting
+  /// (both downloads and uploads) with the new setting.
+  /// Reschedules running download tasks if [rescheduleRunningTasks] is true,
+  /// otherwise leaves those running with their prior setting.
+  /// Restarts running upload tasks if [alsoRestartUploads] is true (which
+  /// requires [rescheduleRunningTasks] to be true as well).
   Future<bool> requireWiFi(
     RequireWiFi requirement, {
     final rescheduleRunningTasks = true,
-  }) => _downloader.requireWiFi(requirement, rescheduleRunningTasks);
+    final alsoRestartUploads = false,
+  }) {
+    assert(
+      !(alsoRestartUploads && !rescheduleRunningTasks),
+      'alsoRestartUploads can only be set if rescheduleRunningTasks is true',
+    );
+    return _downloader.requireWiFi(
+      requirement,
+      rescheduleRunningTasks,
+      alsoRestartUploads,
+    );
+  }
 
   /// Returns the current global setting for requiring WiFi
   Future<RequireWiFi> getRequireWiFiSetting() =>

--- a/lib/src/native_downloader.dart
+++ b/lib/src/native_downloader.dart
@@ -391,10 +391,12 @@ abstract base class NativeDownloader extends BaseDownloader {
   Future<bool> requireWiFi(
     RequireWiFi requirement,
     rescheduleRunningTasks,
+    alsoRestartUploads,
   ) async {
     return await methodChannel.invokeMethod('requireWiFi', [
           requirement.index,
           rescheduleRunningTasks,
+          alsoRestartUploads,
         ]) ??
         false;
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: background_downloader
 description: A multi-platform background file downloader and uploader. Define the task, enqueue and monitor progress
 
-version: 9.5.7
+version: 9.5.8
 repository: https://github.com/781flyingdutchman/background_downloader
 
 environment:


### PR DESCRIPTION
Adds an `alsoRestartUploads` optional parameter to `FileDownloader().requireWiFi()` (defaulting to `false`) to forcefully restart running uploads by cancelling and re-enqueuing them. Enqueued uploads are also naturally picked up and rescheduled.

---
*PR created automatically by Jules for task [544586763950604446](https://jules.google.com/task/544586763950604446) started by @781flyingdutchman*