### PR TITLE
iOS: remove the partial multipart file when createMultipartFile fails

### DIFF
--- a/ios/background_downloader/Sources/background_downloader/Uploader.swift
+++ b/ios/background_downloader/Sources/background_downloader/Uploader.swift
@@ -40,8 +40,22 @@ public class Uploader : NSObject, URLSessionTaskDelegate, StreamDelegate {
     
     /// Creates the multipart file so it can be uploaded
     ///
-    /// Returns true if successful, false otherwise
+    /// Returns true if successful, false otherwise. On failure the partially
+    /// written file is removed: no urlSessionTask is created for it, so
+    /// `didCompleteWithError` - the only other place that deletes it - never
+    /// runs, and the file would remain in the temporary directory forever.
+    /// That matters most when the failure was caused by running out of space,
+    /// as the partial file then holds on to the very space a retry needs.
     public func createMultipartFile() -> Bool {
+        if writeMultipartFile() {
+            return true
+        }
+        try? FileManager.default.removeItem(at: outputFileUrl())
+        return false
+    }
+
+    /// Writes the multipart file, returning true if successful
+    private func writeMultipartFile() -> Bool {
         // create the output file
         FileManager.default.createFile(atPath: outputFileUrl().path,  contents:Data(" ".utf8), attributes: nil)
         guard let fileHandle = try? FileHandle(forWritingTo: outputFileUrl()) else {
@@ -124,7 +138,8 @@ public class Uploader : NSObject, URLSessionTaskDelegate, StreamDelegate {
     
     /// Return the URL of the generated outputfile with multipart data
     ///
-    /// Should only be called after calling createMultipartFile, and only when that returns true
+    /// Callers outside this class should only use this after calling
+    /// createMultipartFile, and only when that returns true
     func outputFileUrl() -> URL {
         return FileManager.default.temporaryDirectory.appendingPath(outputFilename)
     }


### PR DESCRIPTION
Fixes #701

When `createMultipartFile()` fails, `scheduleUpload` returns without creating a `URLSessionUploadTask`, so `didCompleteWithError` — the only place that removes the temporary body — never runs, and the partial file stays in the temporary directory. `uploaderForUrlSessionTaskIdentifier` is only populated after `createMultipartFile()` succeeds, so the delegate could not find the uploader even if it did run.

That leak is self-defeating in the case that causes it most often. The likeliest reason for the write to fail is running out of space — the reason #539 was raised — and the write proceeds until the volume is full, so the partial file then holds on to the very space a retry needs. `outputFilename` is a fresh `NSUUID()` per `Uploader`, so retrying the same task writes a *new* file rather than reusing the old one, and attempts accumulate. The random name also means the application cannot clean up after the plugin: it has no way to tell these files apart from its own in `NSTemporaryDirectory()`.

The result is that the graceful failure #539 asked for ("it would be best if the upload is retried at a later time") is not something an app can act on. Waiting for transfers already in flight to finish and free their copies is exactly the right response, but each refused attempt has already taken the space that would have made it succeed.

**The change**

The existing body moves to a private `writeMultipartFile()`, and `createMultipartFile()` becomes a thin wrapper that removes the file when it returns false:

```swift
public func createMultipartFile() -> Bool {
    if writeMultipartFile() {
        return true
    }
    try? FileManager.default.removeItem(at: outputFileUrl())
    return false
}
```

Two reasons for doing it here rather than at the call site in `scheduleUpload`:

- it covers *every* failure path, not just the write — the output file is created on the first line, so the `guard let fileHandle`, the missing-source-file check and the stream failures all leak today too;
- it keeps the cleanup inside `Uploader`, so `outputFileUrl()`'s "only after `createMultipartFile()` returned true" contract still holds for callers outside the class. Its doc comment is adjusted to say that explicitly.

`try?` rather than `try`, since a cleanup failure should not change what the caller is told about the upload.

**Testing**

No test added — the failure needs a genuinely full volume to reproduce, and I could not find an existing harness for the native uploader that could stand in for one. Verified by inspection against `dev`, and the file parses clean (`swiftc -parse`). Happy to add coverage if you can point me at the right place for it.

iOS/macOS only. Android's `UploadTaskRunner` writes the multipart body straight to `connection.outputStream`, so there is no temporary copy to leak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
