### PR TITLE
feat(ios): post a NotificationCenter notification on every task status change

### DIFF
--- a/doc/status_updates.md
+++ b/doc/status_updates.md
@@ -91,3 +91,42 @@ In addition to normal percentage values (0.0 to 1.0), the `progress` field can a
 *   `progressPaused` (-5.0): Task is `paused`
 
 For example, if you receive a `TaskProgressUpdate` with a `progress` of `-1.0` (`progressFailed`), you know the task has failed, and the UI can reflect an error state on the progress bar.
+
+## Observing status changes from native iOS code
+
+Task callbacks run in a background isolate that has no access to plugins, so
+code reacting to a status change cannot reach a platform framework from Dart.
+That matters when the app is not running: iOS wakes the app to deliver
+`URLSession` events, the package processes them, but the only thing that can
+show progress in that window — a Live Activity, a widget timeline reload — lives
+behind ActivityKit or WidgetKit and is therefore out of reach.
+
+For those cases the plugin posts `BDPlugin.taskStatusDidChange` on
+`NotificationCenter` for every status change, whatever the task's `updates`
+setting:
+
+```swift
+import background_downloader
+
+NotificationCenter.default.addObserver(
+    forName: BDPlugin.taskStatusDidChange,
+    object: nil,
+    queue: .main
+) { notification in
+    guard let info = notification.userInfo,
+          let taskId = info["taskId"] as? String,
+          let rawStatus = info["status"] as? Int else { return }
+    // 2 == complete, see TaskStatus
+    if rawStatus == 2 {
+        // e.g. advance a Live Activity, reload a widget timeline
+    }
+}
+```
+
+`userInfo` carries `taskId`, `group` and `status` (the `TaskStatus` raw value),
+plus `responseStatusCode` when the server provided one.
+
+This is iOS only, and deliberately minimal: it reports that something happened,
+and leaves what to do about it entirely to the app. On Android the equivalent
+need is usually covered by the foreground-service notification the package
+already posts.

--- a/ios/background_downloader/Sources/background_downloader/BDPlugin.swift
+++ b/ios/background_downloader/Sources/background_downloader/BDPlugin.swift
@@ -56,6 +56,22 @@ public class BDPlugin: NSObject, FlutterPlugin, UNUserNotificationCenterDelegate
     public static var backgroundChannel: FlutterMethodChannel? // for native <-> plugin comms
     public static var callbackChannel: FlutterMethodChannel? // for native to trigger task callbacks
     public static var flutterPluginRegistrantCallback: FlutterPluginRegistrantCallback?
+
+    /// Posted on every task status change, including those that arrive while the
+    /// app was woken in the background to service a URLSession event.
+    ///
+    /// Exists for native code that must react at a moment when Dart cannot: task
+    /// callbacks run in a background isolate without access to plugins, so a
+    /// Live Activity update, a `WidgetCenter.reloadTimelines` call or anything
+    /// else going through a platform framework has no way to be triggered from
+    /// there. Observing this on the main app's side does.
+    ///
+    /// `userInfo` carries `taskId`, `group` and `status` (the `TaskStatus` raw
+    /// value), plus `responseStatusCode` when the server provided one.
+    ///
+    /// Posted regardless of the task's `updates` setting: a native observer is
+    /// independent of whether Dart asked to be told.
+    public static let taskStatusDidChange = Notification.Name("com.bbflight.background_downloader.taskStatusDidChange")
     
     public static func register(with registrar: FlutterPluginRegistrar) {
         let channel = FlutterMethodChannel(name: "com.bbflight.background_downloader", binaryMessenger: registrar.messenger())

--- a/ios/background_downloader/Sources/background_downloader/TaskFunctions.swift
+++ b/ios/background_downloader/Sources/background_downloader/TaskFunctions.swift
@@ -378,6 +378,26 @@ func processStatusUpdate(task: Task, status: TaskStatus, taskException: TaskExce
 
     // Normal status update
 
+    // Let native observers know, before any of the Dart-facing work below and
+    // regardless of the task's `updates` setting. This is the only moment the
+    // app's own code is reachable when the status arrived while the app was
+    // woken in the background: the Dart callbacks run in an isolate with no
+    // access to plugins, so anything needing a platform framework — ActivityKit,
+    // WidgetKit — can only be driven from here.
+    var statusChangeInfo: [String: Any] = [
+        "taskId": task.taskId,
+        "group": task.group,
+        "status": status.rawValue
+    ]
+    if let responseStatusCode = responseStatusCode {
+        statusChangeInfo["responseStatusCode"] = responseStatusCode
+    }
+    NotificationCenter.default.post(
+        name: BDPlugin.taskStatusDidChange,
+        object: nil,
+        userInfo: statusChangeInfo
+    )
+
     // Post update if task expects one, or if failed and retry is needed
     let retryNeeded = status == TaskStatus.failed && task.retriesRemaining > 0
     // if task is in final state, process a final progressUpdate


### PR DESCRIPTION
Closes #702.

Task callbacks run in a background isolate with no access to plugins, so an app
cannot reach a platform framework from Dart at the moment a status arrives. That
is exactly the window that matters on iOS: the system wakes the app to deliver
`URLSession` events while it is otherwise suspended, and the only UI that can
show progress in that window — a Live Activity, a widget timeline — lives behind
ActivityKit or WidgetKit.

### What this does

Posts `BDPlugin.taskStatusDidChange` on `NotificationCenter` from
`processStatusUpdate`, which is already the single funnel every status change
passes through. `userInfo` carries `taskId`, `group`, `status` (the `TaskStatus`
raw value) and `responseStatusCode` when the server provided one.

Posted regardless of the task's `updates` setting, since a native observer is
independent of whether Dart asked to be told, and posted before the Dart-facing
work below it so the early returns in that path cannot swallow it.

```swift
NotificationCenter.default.addObserver(
    forName: BDPlugin.taskStatusDidChange, object: nil, queue: .main
) { notification in
    // advance a Live Activity, reload a widget timeline, …
}
```

### Why this shape

- Additive: no signature changes, no new dependency, and an app that does not
  observe it cannot tell the difference.
- Not ActivityKit-specific — the package keeps no opinion about what the app
  does with the event, and gains no framework dependency.
- iOS only, where the constraint exists.

Happy to switch it to a static closure (`BDPlugin.onTaskStatusChange`) if you
prefer that over a notification — same call site, tell me which you'd rather
maintain.

### Verification

`example` builds for device (`flutter build ios --no-codesign`). `dart format`
and `flutter analyze` are clean on both the package and the example. The change
is native-only, so it is not covered by the Dart tests; I have not been able to
verify on-device delivery of the notification during a background wake, which is
the one behaviour worth a second pair of eyes.

Docs added to `doc/status_updates.md`.
