### PR TITLE
feat(android): opt-in Live Update for the running progress notification

### DIFF
--- a/android/src/main/kotlin/com/bbflight/background_downloader/Notifications.kt
+++ b/android/src/main/kotlin/com/bbflight/background_downloader/Notifications.kt
@@ -74,10 +74,45 @@ class NotificationConfig(
     val canceled: TaskNotification?,
     val progressBar: Boolean,
     val tapOpensFile: Boolean,
-    val groupNotificationId: String
+    val groupNotificationId: String,
+    val promoteToLiveUpdate: Boolean = false
 ) {
     override fun toString(): String {
-        return "NotificationConfig(running=$running, complete=$complete, error=$error, paused=$paused, progressBar=$progressBar, tapOpensFile=$tapOpensFile, groupNotificationId=$groupNotificationId)"
+        return "NotificationConfig(running=$running, complete=$complete, error=$error, paused=$paused, progressBar=$progressBar, tapOpensFile=$tapOpensFile, groupNotificationId=$groupNotificationId, promoteToLiveUpdate=$promoteToLiveUpdate)"
+    }
+}
+
+/**
+ * Sets the progress indicator on [builder], for a [progress] value where
+ * 0..1 is determinate and > 1 means indeterminate.
+ *
+ * With [promote] and on Android 16+, uses [NotificationCompat.ProgressStyle] and asks
+ * for the notification to be promoted, which keeps it on the lock screen and in the
+ * status bar chip for as long as the task runs — the platform's Live Update. The
+ * progress is expressed as one segment of length 100 so the value is simply a
+ * percentage.
+ *
+ * Falls back to the classic progress bar below Android 16, when promotion was not
+ * requested, and when progress is indeterminate: a Live Update whose tracker cannot
+ * move is worse than an ordinary notification.
+ */
+private fun setNotificationProgress(builder: Builder, progress: Double, promote: Boolean) {
+    val indeterminate = progress > 1
+    if (promote && !indeterminate && Build.VERSION.SDK_INT >= 36) {
+        builder.setStyle(
+            NotificationCompat.ProgressStyle()
+                .setProgressSegments(listOf(NotificationCompat.ProgressStyle.Segment(100)))
+                .setProgress((progress * 100).roundToInt())
+        )
+        // Promotion requires the notification to be ongoing. It already is whenever
+        // the task runs in a foreground service, but the flag has to be explicit for
+        // the notification to qualify on its own.
+        builder.setOngoing(true)
+        builder.setRequestPromotedOngoing(true)
+    } else if (indeterminate) {
+        builder.setProgress(100, 0, true)
+    } else {
+        builder.setProgress(100, (progress * 100).roundToInt(), false)
     }
 }
 
@@ -561,13 +596,11 @@ object NotificationService {
         val progressBar =
             taskWorker.notificationConfig?.progressBar == true && (notificationType == NotificationType.running || notificationType == NotificationType.paused)
         if (progressBar && taskWorker.notificationProgress >= 0) {
-            if (taskWorker.notificationProgress <= 1) {
-                builder.setProgress(
-                    100, (taskWorker.notificationProgress * 100).roundToInt(), false
-                )
-            } else { // > 1 means indeterminate
-                builder.setProgress(100, 0, true)
-            }
+            setNotificationProgress(
+                builder,
+                taskWorker.notificationProgress,
+                taskWorker.notificationConfig?.promoteToLiveUpdate == true && notificationType == NotificationType.running
+            )
         }
         addNotificationActions(taskWorker, notificationType, builder)
         addToNotificationQueue(taskWorker, notificationType, builder)
@@ -665,11 +698,11 @@ object NotificationService {
                 val progressBar =
                     groupNotification.notificationConfig.progressBar && (notification == groupNotification.notificationConfig.running)
                 if (progressBar && progress >= 0) {
-                    if (progress <= 1) {
-                        builder.setProgress(100, (progress * 100).roundToInt(), false)
-                    } else { // > 1 means indeterminate
-                        builder.setProgress(100, 0, true)
-                    }
+                    setNotificationProgress(
+                        builder,
+                        progress,
+                        groupNotification.notificationConfig.promoteToLiveUpdate && !isFinished
+                    )
                 }
                 addGroupNotificationActions(
                     taskWorker,

--- a/doc/notifications.md
+++ b/doc/notifications.md
@@ -85,6 +85,37 @@ adding `tapOpensFile: true` to your call to `configureNotifications`, and you do
 register a `taskNotificationTapCallback`.
 
 
+## Live Updates (Android 16+)
+
+Android 16 can promote an ongoing notification to a _Live Update_, keeping it on
+the lock screen and in the status bar chip for as long as the task runs. Set
+`promoteToLiveUpdate` to ask for that:
+
+```dart
+FileDownloader().configureNotification(
+    running: const TaskNotification('Downloading', 'file: {filename}'),
+    progressBar: true, // required: promotion applies to the progress indicator
+    promoteToLiveUpdate: true);
+```
+
+It works the same way on `configureNotificationForGroup` and
+`configureNotificationForTask`.
+
+`progressBar: true` is required, since this changes how the progress indicator
+is rendered. Only the `running` notification is promoted, and only while
+progress is determinate — a Live Update whose tracker cannot move is worse than
+an ordinary notification. Below Android 16, and on iOS, the setting is ignored
+and you get the usual progress bar, so it is safe to set unconditionally.
+
+Promotion requires the app to declare an extra permission in its
+`AndroidManifest.xml`, alongside `POST_NOTIFICATIONS`:
+
+```xml
+<uses-permission android:name="android.permission.POST_PROMOTED_NOTIFICATIONS" />
+```
+
+Without it the notification still shows, simply not promoted.
+
 ## Setup for notifications
 
 __On iOS__: Add the following to your `AppDelegate.swift`:

--- a/lib/src/file_downloader.dart
+++ b/lib/src/file_downloader.dart
@@ -876,6 +876,7 @@ interface class FileDownloader {
     bool progressBar = false,
     bool tapOpensFile = false,
     String groupNotificationId = '',
+    bool promoteToLiveUpdate = false,
   }) {
     _addOrUpdateTaskNotificationConfig(
       TaskNotificationConfig(
@@ -888,6 +889,7 @@ interface class FileDownloader {
         progressBar: progressBar,
         tapOpensFile: tapOpensFile,
         groupNotificationId: groupNotificationId,
+        promoteToLiveUpdate: promoteToLiveUpdate,
       ),
     );
     return this;
@@ -948,6 +950,7 @@ interface class FileDownloader {
     bool progressBar = false,
     bool tapOpensFile = false,
     String groupNotificationId = '',
+    bool promoteToLiveUpdate = false,
   }) {
     _addOrUpdateTaskNotificationConfig(
       TaskNotificationConfig(
@@ -960,6 +963,7 @@ interface class FileDownloader {
         progressBar: progressBar,
         tapOpensFile: tapOpensFile,
         groupNotificationId: groupNotificationId,
+        promoteToLiveUpdate: promoteToLiveUpdate,
       ),
     );
     return this;
@@ -1020,6 +1024,7 @@ interface class FileDownloader {
     bool progressBar = false,
     bool tapOpensFile = false,
     String groupNotificationId = '',
+    bool promoteToLiveUpdate = false,
   }) {
     _addOrUpdateTaskNotificationConfig(
       TaskNotificationConfig(
@@ -1032,6 +1037,7 @@ interface class FileDownloader {
         progressBar: progressBar,
         tapOpensFile: tapOpensFile,
         groupNotificationId: groupNotificationId,
+        promoteToLiveUpdate: promoteToLiveUpdate,
       ),
     );
     return this;

--- a/lib/src/models.dart
+++ b/lib/src/models.dart
@@ -513,6 +513,7 @@ final class TaskNotificationConfig {
   final bool progressBar;
   final bool tapOpensFile;
   final String groupNotificationId;
+  final bool promoteToLiveUpdate;
 
   /// Create notification configuration that determines what notifications are shown,
   /// whether a progress bar is shown (Android only), and whether tapping
@@ -539,6 +540,12 @@ final class TaskNotificationConfig {
   ///    [complete] notification is shown (if configured). If any task in the
   ///    groupNotification fails, the [error] notification is shown.
   ///    The first character of the [groupNotificationId] cannot be '*'.
+  /// [promoteToLiveUpdate] if set asks Android 16+ to promote the running
+  ///    notification to a Live Update, keeping it on the lock screen and in the
+  ///    status bar chip for as long as the task runs (Android only, requires the
+  ///    app to declare the POST_PROMOTED_NOTIFICATIONS permission). Ignored
+  ///    below Android 16 and while progress is indeterminate, which fall back to
+  ///    the ordinary progress bar.
   TaskNotificationConfig({
     this.taskOrGroup,
     this.running,
@@ -549,6 +556,7 @@ final class TaskNotificationConfig {
     this.progressBar = false,
     this.tapOpensFile = false,
     this.groupNotificationId = '',
+    this.promoteToLiveUpdate = false,
   }) {
     assert(
       running != null ||
@@ -571,6 +579,7 @@ final class TaskNotificationConfig {
     'progressBar': progressBar,
     'tapOpensFile': tapOpensFile,
     'groupNotificationId': groupNotificationId,
+    'promoteToLiveUpdate': promoteToLiveUpdate,
   };
 
   @override


### PR DESCRIPTION
Closes #703.

Android 16 can promote an ongoing notification to a **Live Update**, keeping it
on the lock screen and in the status bar chip for as long as the task runs. A
long download or upload is one of the cases it was designed for, and the
notification this package already posts is nearly eligible: ongoing under a
foreground service, content title set, no custom `RemoteViews` layout, not
colorized.

### What this does

Adds `promoteToLiveUpdate` to `TaskNotificationConfig`, **off by default**, and
threads it through `configureNotification`,
`configureNotificationForGroup` and `configureNotificationForTask` so it is
reachable from the documented entry points rather than only by constructing a
config directly.

Both the per-task and the group progress notification now go through one helper,
`setNotificationProgress`, so the two paths cannot drift. When the flag is set,
on API 36+, and while progress is determinate, it uses
`NotificationCompat.ProgressStyle` with a single 100-unit segment — so the value
is simply a percentage — and calls `setRequestPromotedOngoing`.

Everything else falls back to the existing `setProgress` bar: below API 36, when
the flag is not set, and on indeterminate progress, where a Live Update whose
tracker cannot move would be worse than an ordinary notification. Only the
`running` notification is promoted, never the finished ones.

### Why this is smaller than it looks

- **No dependency change.** `NotificationCompat.ProgressStyle` and
  `NotificationCompat.Builder#setRequestPromotedOngoing` arrived in
  `androidx.core` **1.16**; the package is already on **1.17.0** with
  `compileSdk 36`.
- **Backwards compatible on the wire.** The Kotlin `NotificationConfig` field
  has a default, so a config serialized without the key still decodes, and the
  Swift `Codable` struct ignores the extra JSON key.
- The eligibility rules are satisfied by the existing builder; `setOngoing(true)`
  is set explicitly on the promoted path so the notification qualifies on its
  own rather than only by virtue of the foreground service.

### One thing the app must do

Promotion requires `POST_PROMOTED_NOTIFICATIONS` in the **app's** manifest,
which a plugin cannot declare on its behalf. Documented in
`doc/notifications.md` next to the flag. Without it the notification still
shows, simply not promoted.

### Verification

`example` builds (`flutter build apk --debug`), which is what actually proves
the two new androidx APIs resolve at 1.17.0. `flutter test` passes (79 tests),
and `dart format` and `flutter analyze` are clean on both the package and the
example. I have not been able to confirm the promoted appearance on an API 36
device — that is the part worth checking before merge.

I left `CHANGELOG.md` and `pubspec.yaml` alone, since that seems to be yours to
do at release time; happy to add an entry if you'd rather have it in the PR.
