### PR TITLE
docs: Clarify single-subscription nature of updates stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,10 @@ switch (result.status) {
 // enqueue, and can enqueue hundreds of tasks simultaneously.
 
 // First define an event listener to process `TaskUpdate` events sent to you by the downloader, 
-// typically in your app's `initState()`:
+// typically in your app's `initState()`.
+// Note that the `updates` stream is a single-subscription stream.
+// If you are developing a package or plugin, you should instead use `FileDownloader().registerCallbacks`
+// with a custom group to monitor tasks without preventing the main application from listening to the stream.
 FileDownloader().updates.listen((update) {
       switch (update) {
         case TaskStatusUpdate():

--- a/doc/database.md
+++ b/doc/database.md
@@ -40,6 +40,8 @@ See [Status & Progress Updates](status_updates.md) for full details on what info
 
 Listen to updates from the downloader by listening to the `updates` stream.
 
+**Important**: The `updates` stream is a single-subscription stream. It can only be listened to once. Attempting to listen to it multiple times will result in a "Bad state: Stream has already been listened to" error. If you are developing a package or plugin, you should **not** listen to this stream, as doing so will prevent the main application from listening to it. Instead, use [callbacks](#option-2-using-callbacks) with a custom group to monitor tasks specific to your package.
+
 ```dart
     final subscription = FileDownloader().updates.listen((update) {
       switch(update) {
@@ -64,6 +66,8 @@ Note that `successFullyEnqueued` only refers to the enqueueing of the download t
 ### Option 2: Using callbacks
 
 Instead of listening to the `updates` stream you can register a callback for status updates, and/or a callback for progress updates. This may be the easiest way if you want different callbacks for different [groups](lifecycle.md#grouping-tasks).
+
+**Important for package developers**: Tasks belonging to a group that has registered callbacks will **not** emit updates to the `updates` stream. This makes `registerCallbacks` the preferred way for packages to monitor their own tasks, as it avoids interfering with the main application's single-subscription listener on the `updates` stream.
 
 ```dart
 // define callbacks

--- a/lib/src/file_downloader.dart
+++ b/lib/src/file_downloader.dart
@@ -74,7 +74,13 @@ interface class FileDownloader {
   Future<bool> get ready => _downloader.ready;
 
   /// Stream of [TaskUpdate] updates for downloads that do
-  /// not have a registered callback
+  /// not have a registered callback.
+  ///
+  /// **Important**: This is a single-subscription stream. It can only be listened to
+  /// once. If you are developing a package or plugin, you should **not** listen
+  /// to this stream, as doing so will prevent the main application from listening to it.
+  /// Instead, use [registerCallbacks] with a custom group to monitor tasks specific
+  /// to your package.
   Stream<TaskUpdate> get updates => _downloader.updates.stream;
 
   /// Accesses utilities for working with URIs. URIs make working with file pickers and
@@ -135,6 +141,12 @@ interface class FileDownloader {
   /// appropriate callbacks are called for that group.
   /// For the `taskNotificationTapCallback` callback, the `defaultGroup` callback
   /// is used when calling 'convenience' functions like `FileDownloader().download`
+  ///
+  /// **Important for package developers**: Tasks belonging to a group that has
+  /// registered callbacks will **not** emit updates to the [updates] stream.
+  /// This makes [registerCallbacks] the preferred way for packages to monitor
+  /// their own tasks, as it avoids interfering with the main application's
+  /// single-subscription listener on the [updates] stream.
   ///
   /// The call returns the [FileDownloader] to make chaining easier
   FileDownloader registerCallbacks({


### PR DESCRIPTION
This PR clarifies the documentation regarding the `updates` stream, addressing an issue where third-party packages listening to `updates` would cause a "Bad state: Stream has already been listened to" error for the main application. It directs package developers to use `registerCallbacks` instead.

---
*PR created automatically by Jules for task [16380926759464464732](https://jules.google.com/task/16380926759464464732) started by @781flyingdutchman*