### PR TITLE
Fix Android Expedited WorkManager delay crash

### DIFF
--- a/android/src/main/kotlin/com/bbflight/background_downloader/BDPlugin.kt
+++ b/android/src/main/kotlin/com/bbflight/background_downloader/BDPlugin.kt
@@ -144,6 +144,14 @@ class BDPlugin : FlutterPlugin, MethodCallHandler, ActivityAware,
             initialDelayMillis: Long = 0,
             plugin: BDPlugin? = null
         ): Boolean {
+            val expedited = task.priority < 5 && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+            val actualDelayMillis = if (initialDelayMillis > 0 && expedited) {
+                kotlinx.coroutines.delay(initialDelayMillis)
+                0L
+            } else {
+                initialDelayMillis
+            }
+
             Log.i(TAG, "Enqueuing task with id ${task.taskId}")
             // store backgroundChannel to be used by this task
             val bgChannel = backgroundChannel(plugin)
@@ -194,8 +202,8 @@ class BDPlugin : FlutterPlugin, MethodCallHandler, ActivityAware,
                     .setRequiresCharging(false)
                     .setExtras(extras)
                 
-                if (initialDelayMillis > 0) {
-                    jobInfoBuilder.setMinimumLatency(initialDelayMillis)
+                if (actualDelayMillis > 0L) {
+                    jobInfoBuilder.setMinimumLatency(actualDelayMillis)
                 }
                 // JobScheduler will persist tasks across reboots if strictly necessary, 
                 // but WorkManager handles this better. 
@@ -235,10 +243,10 @@ class BDPlugin : FlutterPlugin, MethodCallHandler, ActivityAware,
                 ).build()
                 val requestBuilder: OneTimeWorkRequest.Builder =
                     createRequestBuilder(task, data, constraints) ?: return false
-                if (initialDelayMillis != 0L) {
-                    requestBuilder.setInitialDelay(initialDelayMillis, TimeUnit.MILLISECONDS)
+                if (actualDelayMillis != 0L) {
+                    requestBuilder.setInitialDelay(actualDelayMillis, TimeUnit.MILLISECONDS)
                 }
-                val expedited = task.priority < 5 && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+
                 if (expedited) {
                     requestBuilder.setExpedited(policy = OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
                 }
@@ -251,9 +259,9 @@ class BDPlugin : FlutterPlugin, MethodCallHandler, ActivityAware,
                              Log.i(TAG, "Could not enqueue expedited task, falling back to non-expedited")
                              val nonExpeditedRequestBuilder =
                                  createRequestBuilder(task, data, constraints) ?: throw e
-                             if (initialDelayMillis != 0L) {
+                             if (actualDelayMillis != 0L) {
                                  nonExpeditedRequestBuilder.setInitialDelay(
-                                     initialDelayMillis,
+                                     actualDelayMillis,
                                      TimeUnit.MILLISECONDS
                                  )
                              }


### PR DESCRIPTION
Fix WorkManager crash when enqueuing expedited tasks with initial delays

Android WorkManager throws an `IllegalArgumentException` when an expedited task (priority < 5 on SDK >= S) is configured with an initial delay. This causes tasks to hang indefinitely in a paused state when attempting to restart (e.g. after a 9-minute limit) because the crash is caught and ignored. 

This fixes the issue by shifting the delay logic to a coroutine `delay()` inside `doEnqueue` specifically when an expedited task is requested with an initial delay, avoiding passing the delay directly to the `WorkRequest.Builder`.

iOS priority mapping logic was reviewed and confirmed correct as mapping 0 to 10 onto 1.0 to 0.0 is acceptable.

---
*PR created automatically by Jules for task [4124619222977422421](https://jules.google.com/task/4124619222977422421) started by @781flyingdutchman*