### PR TITLE
Stable ordering for concurrent running download notifications on Android

### DIFF
--- a/android/src/main/kotlin/com/bbflight/background_downloader/Notifications.kt
+++ b/android/src/main/kotlin/com/bbflight/background_downloader/Notifications.kt
@@ -533,6 +533,18 @@ object NotificationService {
             taskWorker.appContext, notificationChannelId
         ).setPriority(NotificationCompat.PRIORITY_LOW).setSmallIcon(iconDrawable)
             .setShowWhen(notificationType != NotificationType.running)
+        if (notificationType == NotificationType.running) {
+            // Keep concurrent download notifications in a stable order.
+            // Without an explicit `when`, every progress update re-stamps
+            // the notification with the current time, and the shade
+            // re-ranks the app's notifications on each tick, so two
+            // running downloads constantly swap places. Pin `when` to the
+            // task's creation time (hidden by setShowWhen above) and add
+            // a deterministic sort key as a tie-breaker.
+            builder.setWhen(taskWorker.task.creationTime)
+                .setSortKey(taskWorker.task.taskId)
+                .setOnlyAlertOnce(true)
+        }
         // use stored progress if notificationType is .paused
         taskWorker.notificationProgress =
             if (notificationType == NotificationType.paused) taskWorker.notificationProgress else progress


### PR DESCRIPTION
Fixes #713.

With two or more tasks downloading at the same time, each with a `running` TaskNotification, the notifications keep swapping positions in the Android shade. The running notification is built with `setShowWhen(false)` but no explicit `when`, so every `notify()` stamps it with the current time internally, and the shade ranks the app's notifications by that value. Two tasks updating in turn get alternating timestamps and their order flips on almost every progress tick.

The change pins `when` to the task's creation time for running notifications (the value stays hidden because `setShowWhen(false)` is already set), adds the task id as a deterministic sort key for tasks created in the same millisecond, and sets `setOnlyAlertOnce(true)` so progress updates cannot re-alert. Ordering becomes stable while progress keeps updating smoothly; completed/error/paused notifications are unaffected.

Verified on a Samsung Galaxy S25: before the change, two concurrent downloads leapfrog constantly; after it, they hold their positions until they finish. Group notifications are not affected by this path and behave as before.

Scope is deliberately Android only, matching the issue: the desktop implementations show no notifications, and I have not observed the problem on iOS. Happy to add a CHANGELOG entry if you would like one.
