### PR TITLE
Clarify requireWiFi platform behavior on Android and iOS

### DIFF
--- a/doc/lifecycle.md
+++ b/doc/lifecycle.md
@@ -113,6 +113,10 @@ By default, whether a task requires WiFi or not is determined by its `requireWiF
 
 When calling `FileDownloader().requireWiFi`, all enqueued tasks will be canceled and rescheduled with the appropriate WiFi requirement setting. If the `rescheduleRunningTasks` parameter is true, all running download tasks will be paused (if possible, independent of the task's `allowPause` property) and resumed with the new WiFi requirement. If the `alsoRestartUploads` parameter is true (which requires `rescheduleRunningTasks` to also be true), running upload tasks will be forcefully canceled and restarted from scratch. All newly enqueued tasks will follow this setting as well.
 
+Note that requiring WiFi enforces platform-specific network constraints:
+* On **Android**, tasks require an unmetered network connection. They will not execute over cellular data or metered Wi-Fi networks (e.g. mobile hotspots), but will execute over unmetered Wi-Fi or unmetered Ethernet.
+* On **iOS**, cellular access is disabled for the tasks. They will execute over any non-cellular connection (Wi-Fi or Ethernet), even if the Wi-Fi network is a mobile hotspot or metered.
+
 The global setting persists across application restarts. Check the current setting by calling `FileDownloader().getRequireWiFiSetting`.
 
 ## Authentication and pre- and post-execution callbacks

--- a/doc/parameters.md
+++ b/doc/parameters.md
@@ -37,7 +37,11 @@ Note that certain failures can be resumed, and retries will therefore attempt to
 
 ### Requiring WiFi
 
-On Android and iOS only: If the `requiresWiFi` field of a `Task` is set to true, the task won't start unless a WiFi network is available. By default `requiresWiFi` is false, and downloads/uploads will use the cellular (or metered) network if WiFi is not available, which may incur cost. Note that every task requires a working internet connection: local server connections that do not reach the internet may not work.
+On Android and iOS only: If the `requiresWiFi` field of a `Task` is set to true, the task is restricted to non-metered / non-cellular connections. By default `requiresWiFi` is false, and downloads/uploads will use cellular or metered networks if available, which may incur cost. Note that every task requires a working internet connection: local server connections that do not reach the internet may not work.
+
+The exact behavior of `requiresWiFi` differs between platforms:
+* **Android**: `requiresWiFi` enforces an **unmetered network connection** constraint (`NETWORK_TYPE_UNMETERED`). This means the task will run on standard unmetered Wi-Fi and unmetered Ethernet connections. However, it will **not** run on cellular data OR on metered Wi-Fi networks (such as mobile Wi-Fi hotspots or Wi-Fi networks explicitly marked as metered in Android system settings).
+* **iOS**: `requiresWiFi` disables cellular access (`allowsCellularAccess = false`). This means the task will run on any non-cellular connection (Wi-Fi or Ethernet), even if the Wi-Fi network is a mobile hotspot or metered. It will **not** run over cellular data connections.
 
 ### Priority
 

--- a/lib/src/file_downloader.dart
+++ b/lib/src/file_downloader.dart
@@ -813,6 +813,11 @@ interface class FileDownloader {
   /// otherwise leaves those running with their prior setting.
   /// Restarts running upload tasks if [alsoRestartUploads] is true (which
   /// requires [rescheduleRunningTasks] to be true as well).
+  ///
+  /// Note that on Android, requiring WiFi enforces an unmetered network
+  /// connection constraint (`NETWORK_TYPE_UNMETERED`), excluding metered Wi-Fi
+  /// hotspots and cellular data. On iOS, requiring WiFi disables cellular access
+  /// (`allowsCellularAccess = false`), allowing execution over any Wi-Fi or Ethernet.
   Future<bool> requireWiFi(
     RequireWiFi requirement, {
     final rescheduleRunningTasks = true,

--- a/lib/src/task.dart
+++ b/lib/src/task.dart
@@ -245,7 +245,8 @@ sealed class Task extends Request implements Comparable {
   /// Type of progress updates desired
   final Updates updates;
 
-  /// If true, will not download over cellular (metered) network
+  /// If true, task is restricted to non-metered / non-cellular connections
+  /// (on Android, requires an unmetered network connection; on iOS, disables cellular access).
   final bool requiresWiFi;
 
   /// If true, task will pause if the task fails partly through the execution,
@@ -314,8 +315,9 @@ sealed class Task extends Request implements Comparable {
   /// [group] if set allows different callbacks or processing for different
   /// groups
   /// [updates] the kind of progress updates requested
-  /// [requiresWiFi] if set, will not start download until WiFi is available.
-  /// If not set may start download over cellular network
+  /// [requiresWiFi] if set, restricts task to non-metered / non-cellular connections
+  /// (on Android, requires an unmetered network connection; on iOS, disables cellular access).
+  /// If not set, task may execute over cellular or metered networks.
   /// [retries] if >0 will retry a failed download this many times
   /// [allowPause]
   /// If true, task will pause if the task fails partly through the execution,
@@ -687,8 +689,9 @@ final class DownloadTask extends Task {
   /// [group] if set allows different callbacks or processing for different
   /// groups
   /// [updates] the kind of progress updates requested
-  /// [requiresWiFi] if set, will not start download until WiFi is available.
-  /// If not set may start download over cellular network
+  /// [requiresWiFi] if set, restricts task to non-metered / non-cellular connections
+  /// (on Android, requires an unmetered network connection; on iOS, disables cellular access).
+  /// If not set, task may execute over cellular or metered networks.
   /// [retries] if >0 will retry a failed download this many times
   /// [allowPause] if true, allows pause command
   /// [priority] in range 0 <= priority <= 10 with 0 highest, defaults to 5.
@@ -885,8 +888,9 @@ final class UploadTask extends Task {
   /// [group] if set allows different callbacks or processing for different
   /// groups
   /// [updates] the kind of progress updates requested
-  /// [requiresWiFi] if set, will not start upload until WiFi is available.
-  /// If not set may start upload over cellular network
+  /// [requiresWiFi] if set, restricts task to non-metered / non-cellular connections
+  /// (on Android, requires an unmetered network connection; on iOS, disables cellular access).
+  /// If not set, task may execute over cellular or metered networks.
   /// [priority] in range 0 <= priority <= 10 with 0 highest, defaults to 5.
   /// On Android 14+, setting priority to 0 requires the
   /// `android.permission.RUN_USER_INITIATED_JOBS` permission in AndroidManifest.xml.
@@ -1460,8 +1464,9 @@ final class DataTask extends Task {
   /// [group] if set allows different callbacks or processing for different
   /// groups
   /// [updates] the kind of progress updates requested (only .status or none)
-  /// [requiresWiFi] if set, will not start download until WiFi is available.
-  /// If not set may start download over cellular network
+  /// [requiresWiFi] if set, restricts task to non-metered / non-cellular connections
+  /// (on Android, requires an unmetered network connection; on iOS, disables cellular access).
+  /// If not set, task may execute over cellular or metered networks.
   /// [retries] if >0 will retry a failed download this many times
   /// [priority] in range 0 <= priority <= 10 with 0 highest, defaults to 5.
   /// On Android 14+, setting priority to 0 requires the


### PR DESCRIPTION
Updated documentation and Dart docstrings across doc/parameters.md, doc/lifecycle.md, lib/src/file_downloader.dart, and lib/src/task.dart to explain how requireWiFi operates on Android (unmetered network constraint) and iOS (cellular access disabled).

---
*PR created automatically by Jules for task [7821838134986514509](https://jules.google.com/task/7821838134986514509) started by @781flyingdutchman*