### PR TITLE
Fix iOS group notification category for finished groups

### DIFF
--- a/ios/background_downloader/Sources/background_downloader/BDPlugin.swift
+++ b/ios/background_downloader/Sources/background_downloader/BDPlugin.swift
@@ -951,7 +951,7 @@ public class BDPlugin: NSObject, FlutterPlugin, UNUserNotificationCenterDelegate
                 let taskAsJsonString = userInfo["task"] as? String,
                 let task = taskFrom(jsonString: taskAsJsonString)
             else {
-                os_log("No task", log: log, type: .error)
+                os_log("No task for notification tap", log: log, type: .info)
                 return
             }
             switch response.actionIdentifier {

--- a/ios/background_downloader/Sources/background_downloader/Notifications.swift
+++ b/ios/background_downloader/Sources/background_downloader/Notifications.swift
@@ -292,6 +292,10 @@ func updateGroupNotification(
         {
             if !isFinished {
                 addCancelActionToNotificationGroup(content: content)
+            } else {
+                content.categoryIdentifier = hasError
+                    ? NotificationCategory.error.rawValue
+                    : NotificationCategory.complete.rawValue
             }
             let request = UNNotificationRequest(identifier: await groupNotification.notificationId,
                                                 content: content, trigger: nil)

--- a/ios/background_downloader/Sources/background_downloader/Notifications.swift
+++ b/ios/background_downloader/Sources/background_downloader/Notifications.swift
@@ -274,7 +274,8 @@ func updateGroupNotification(
         guard let notification = notification else
         {
             // remove notification
-            notificationCenter.removeDeliveredNotifications(withIdentifiers: [task.taskId])
+            let notificationId = await groupNotification.notificationId
+            notificationCenter.removeDeliveredNotifications(withIdentifiers: [notificationId])
             return
         }
         // need to show a notification
@@ -290,13 +291,9 @@ func updateGroupNotification(
         }
         if previousNotification.isEmpty || previousNotification.first?.request.content.title != content.title || previousNotification.first?.request.content.body != content.body
         {
-            if !isFinished {
-                addCancelActionToNotificationGroup(content: content)
-            } else {
-                content.categoryIdentifier = hasError
-                    ? NotificationCategory.error.rawValue
-                    : NotificationCategory.complete.rawValue
-            }
+            content.categoryIdentifier = !isFinished
+                ? NotificationCategory.runningWithoutPause.rawValue
+                : (hasError ? NotificationCategory.error.rawValue : NotificationCategory.complete.rawValue)
             let request = UNNotificationRequest(identifier: await groupNotification.notificationId,
                                                 content: content, trigger: nil)
             do {
@@ -350,11 +347,6 @@ func addNotificationActions(task: Task, notificationType: NotificationType, cont
             content.categoryIdentifier = NotificationCategory.canceled.rawValue
         }
     })
-}
-
-/// Add cancel action button to the notificationGroup
-func addCancelActionToNotificationGroup(content: UNMutableNotificationContent) {
-    content.categoryIdentifier = NotificationCategory.runningWithoutPause.rawValue
 }
 
 /// Returns the notificationType related to this [status]


### PR DESCRIPTION
This PR fixes issue #718 on iOS, where group notifications for a finished group were suppressed when the app was in the foreground due to a missing categoryIdentifier.

### Changes:
- **Set category for finished groups & inline category assignment**: In `Notifications.swift`, `updateGroupNotification` now explicitly sets `content.categoryIdentifier` for both running (`.runningWithoutPause`) and finished states (`.error` / `.complete`). This allows `BDPlugin.swift`'s `willPresent` to match the notification category against `ourCategories` and present it in foreground (on iOS 14+ delivering to Notification Center).
- **Remove unused helper**: Removed `addCancelActionToNotificationGroup` in favor of the direct, unified assignment.
- **Fix group notification dismissal**: Fixed `removeDeliveredNotifications` in `updateGroupNotification` to remove `await groupNotification.notificationId` instead of `task.taskId` when no notification content is configured for the current state.
- **Notification tap logging**: `BDPlugin.swift` now logs notification taps without a task payload at `.info` level instead of `.error`.