### PR TITLE
iOS: seek instead of discarding bytes when slicing a partial upload

### DIFF
--- a/ios/background_downloader/Sources/background_downloader/Helpers.swift
+++ b/ios/background_downloader/Sources/background_downloader/Helpers.swift
@@ -64,49 +64,38 @@ func createTempFileWithRange(from fileURL: URL, start: UInt64, contentLength: UI
     let fileManager = FileManager.default
     let tempDir = fileManager.temporaryDirectory
     let tempFileURL = tempDir.appendingPathComponent(UUID().uuidString) // Create a unique temporary file
-    
+
     // Create the temporary file
     fileManager.createFile(atPath: tempFileURL.path, contents: nil, attributes: nil)
-    guard let inputStream = InputStream(url: fileURL),
-          let outputStream = OutputStream(toFileAtPath: tempFileURL.path, append: false) else {
-        os_log("Cannot create input or output stream for partial upload temporary file creation", log: log, type: .error)
+    guard let inputHandle = try? FileHandle(forReadingFrom: fileURL),
+          let outputHandle = try? FileHandle(forWritingTo: tempFileURL) else {
+        os_log("Cannot open file handles for partial upload temporary file creation", log: log, type: .error)
         return nil
     }
-    inputStream.open()
-    outputStream.open()
     defer {
-        inputStream.close()
-        outputStream.close()
+        try? inputHandle.close()
+        try? outputHandle.close()
     }
-    let chunkSize = 1024 * 1024 // 1MB chunks
-    let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: chunkSize)
-    defer { buffer.deallocate() }
+    let bufferSize = 1024 * 1024 // 1MB chunks
     var remainingBytes = contentLength
-    var totalRead: UInt64 = 0
-    
-    // Seek to the start position
-    while totalRead < start {
-        let seekBytes = min(chunkSize, Int(start - totalRead))
-        let bytesRead = inputStream.read(buffer, maxLength: seekBytes)
-        if bytesRead < 0 {
-            os_log("Cannot read data up to desired start from original file for partial upload temporary file creation", log: log, type: .error)
-            return nil
+    do {
+        // Seek to the start position, rather than reading and discarding every
+        // byte before it. Slicing one file into N chunks calls this function N
+        // times with an increasing `start`, so discarding made the total work
+        // quadratic in N: uploading a 800MB file in 61 chunks read ~24GB.
+        try inputHandle.seek(toOffset: start)
+        while remainingBytes > 0 {
+            let bytesToRead = Int(min(UInt64(bufferSize), remainingBytes))
+            guard let data = try inputHandle.read(upToCount: bytesToRead), !data.isEmpty else {
+                break // EOF
+            }
+            try outputHandle.write(contentsOf: data)
+            remainingBytes -= UInt64(data.count)
         }
-        if bytesRead == 0 { break } // EOF
-        totalRead += UInt64(bytesRead)
-    }
-    
-    // Read only the required range
-    while remainingBytes > 0 {
-        let bytesToRead = min(chunkSize, Int(remainingBytes))
-        let bytesRead = inputStream.read(buffer, maxLength: bytesToRead)
-        if bytesRead <= 0 { break } // EOF
-        let bytesWritten = outputStream.write(buffer, maxLength: bytesRead)
-        if bytesWritten < 0 {
-            os_log("Cannot write data to new temporary file for partial upload", log: log, type: .error)
-            return nil
-        }
-        remainingBytes -= UInt64(bytesWritten)
+    } catch {
+        os_log("Cannot create temporary file for partial upload: %@", log: log, type: .error,
+               error.localizedDescription)
+        return nil
     }
     return tempFileURL
 }


### PR DESCRIPTION
## Problem

`createTempFileWithRange` (ios/.../Helpers.swift) copies the requested byte range of a file into a temp file, which a binary `UploadTask` with a `Range` header needs because a background `URLSession` can only upload `fromFile:`.

It reaches `start` by reading and discarding every byte before it:

```swift
while totalRead < start {
    let seekBytes = min(chunkSize, Int(start - totalRead))
    let bytesRead = inputStream.read(buffer, maxLength: seekBytes)
    ...
}
```

Slicing one file into N chunks calls this N times with an increasing `start`, so the bytes read grow with N², while the bytes written stay at the file size. Uploading an 800MB file in 61 chunks reads about 24GB in order to write 800MB of slices, and it all happens inside `enqueueAll`, before the first byte reaches the network. On iOS that window is also what an app has to fit into its background execution assertion, so a large chunked upload can be suspended before its chunks are enqueued.

The Android implementation does not have this problem: `UploadTaskRunner` streams straight from the file with `fis.skip(start)` and never materialises a slice.

## Fix

Use `FileHandle.seek(toOffset:)` so each call reads only the bytes it copies. Cost per call becomes O(contentLength) instead of O(start + contentLength), and the total for N chunks becomes the file size instead of growing quadratically.

The switch to `FileHandle.write(contentsOf:)` also fixes a smaller latent bug: the previous `OutputStream` loop subtracted the written count from `remainingBytes` on a short write but never re-sent the unwritten tail, so a short write silently dropped bytes from the slice.

Min deployment target is iOS 14, so `seek(toOffset:)`, `read(upToCount:)` and `write(contentsOf:)` are all available without a fallback.

## Verification

I ran both implementations side by side in a standalone Foundation harness over a 5MB pseudo-random file, comparing every produced slice against the expected sub-range and against the original implementation's output.

All 10 cases produce byte-identical output to the original, including the edge cases: whole file, aligned chunk, unaligned start, final short chunk, single byte, length past EOF, start past EOF, and zero length.

Bytes read to slice the same file into N chunks:

| N | patched | original |
|---|---|---|
| 1 | 5.0MB | 5.0MB |
| 8 | 5.0MB | 22.6MB |
| 32 | 5.0MB | 82.7MB |
| 64 | 5.0MB | 162.9MB |

Wall-clock on a Mac only improves 1.3–1.5x at these sizes because a 5MB file stays in the page cache, so the discarded reads are nearly free there. The saving is in the I/O the device actually performs; on an iPhone I measured about 51ms per chunk for a 3-chunk 26MB upload, which is real I/O rather than cache.

No public API change, and no change to the Dart layer.