### PR TITLE
Expand connectivity_plus version constraint to support 7.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,6 @@
-## 9.6.2
-
-* Expand `connectivity_plus` version constraint to `>=6.1.3 <8.0.0` to support `connectivity_plus` 7.x (fixes #722)
-
 ## 9.6.1
 
+* Expand `connectivity_plus` version constraint to `>=6.1.3 <8.0.0` to support `connectivity_plus` 7.x (fixes #722)
 * [Android] Enforce Wi-Fi constraint via `NetworkRequest` on Android API 28+: require `TRANSPORT_WIFI` and `NET_CAPABILITY_INTERNET` for tasks requiring Wi-Fi, preventing downloads over cellular even when reported as unmetered by the carrier, with fallback to `NETWORK_TYPE_UNMETERED` on older Android versions (fixes #717)
 * [Documentation] Clarify `requiresWiFi` behavior on Android API 28+ vs earlier Android versions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 9.6.2
+
+* Expand `connectivity_plus` version constraint to `>=6.1.3 <8.0.0` to support `connectivity_plus` 7.x (fixes #722)
+
 ## 9.6.1
 
 * [Android] Enforce Wi-Fi constraint via `NetworkRequest` on Android API 28+: require `TRANSPORT_WIFI` and `NET_CAPABILITY_INTERNET` for tasks requiring Wi-Fi, preventing downloads over cellular even when reported as unmetered by the carrier, with fallback to `NETWORK_TYPE_UNMETERED` on older Android versions (fixes #717)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: background_downloader
 description: A multi-platform background file downloader and uploader. Define the task, enqueue and monitor progress
 
-version: 9.6.1
+version: 9.6.2
 repository: https://github.com/781flyingdutchman/background_downloader
 
 environment:
@@ -18,7 +18,7 @@ dependencies:
   async: ^2.6.0
   mime: ^2.0.0
   collection: ^1.15.0
-  connectivity_plus: ^6.1.3
+  connectivity_plus: '>=6.1.3 <8.0.0'
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: background_downloader
 description: A multi-platform background file downloader and uploader. Define the task, enqueue and monitor progress
 
-version: 9.6.2
+version: 9.6.1
 repository: https://github.com/781flyingdutchman/background_downloader
 
 environment:


### PR DESCRIPTION
Expands the connectivity_plus dependency version constraint in pubspec.yaml to `>=6.1.3 <8.0.0`, allowing downstream projects using connectivity_plus 7.x to resolve without breaking compatibility with 6.x. Also bumps version to 9.6.2 and updates CHANGELOG.md.

---
*PR created automatically by Jules for task [13509601864438533963](https://jules.google.com/task/13509601864438533963) started by @781flyingdutchman*