### PR TITLE
Fix Android R8 build error and update min Flutter SDK in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,8 +16,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # This is Dart 3.7.0
-  FLUTTER_MIN_SDK: '3.29.0'
+  # This is Dart 3.13.0
+  FLUTTER_MIN_SDK: '3.47.0'
 
 jobs:
   format:

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.parallel=true
 org.gradle.caching=true
 android.useAndroidX=true
 android.nonTransitiveRClass=false
-android.nonFinalResIds=false
+android.nonFinalResIds=true
 # This builtInKotlin flag was added automatically by Flutter migrator
 android.builtInKotlin=false
 # This newDsl flag was added automatically by Flutter migrator


### PR DESCRIPTION
This change fixes two GitHub Actions CI build issues:
1. Fixes the Android `:app:minifyReleaseWithR8` build failure on release builds by configuring `android.nonFinalResIds=true` in `example/android/gradle.properties`.
2. Updates `FLUTTER_MIN_SDK` in `.github/workflows/build.yml` from `3.29.0` to `3.47.0` (Dart 3.13.0) to satisfy the plugin's minimum Flutter SDK requirement specified in `pubspec.yaml`.

---
*PR created automatically by Jules for task [2938854137851260072](https://jules.google.com/task/2938854137851260072) started by @781flyingdutchman*